### PR TITLE
GoogleCheese.java uses for-each loop

### DIFF
--- a/examples/google_cheese/pom.xml
+++ b/examples/google_cheese/pom.xml
@@ -31,4 +31,17 @@
             <version>2.20.0</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>5</source>
+                    <target>5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
You should specify JDK's version to avoid the below error.

```
GoogleCheese.java:[50,32] for-each loops are not supported in -source 1.3
(use -source 5 or higher to enable for-each loops)
            for (int driverType : new int[]{0, 1, 2}) {
```
