### PR TITLE
Various improvements.

### DIFF
--- a/src/request_handlers/request_handler.js
+++ b/src/request_handlers/request_handler.js
@@ -30,6 +30,7 @@ var ghostdriver = ghostdriver || {};
 ghostdriver.RequestHandler = function() {
     // private:
     var
+    _errors = require("./errors.js"),
     _handle = function(request, response) {
         _decorateRequest(request);
         _decorateResponse(response);
@@ -62,7 +63,6 @@ ghostdriver.RequestHandler = function() {
 
     _successDecorator = function(sessionId, value) {
         this.statusCode = 200;
-
         if (arguments.length > 0) {
             // write something, only if there is something to write
             this.writeJSONAndClose(_buildSuccessResponseBody(sessionId, value));
@@ -84,6 +84,49 @@ ghostdriver.RequestHandler = function() {
         this.close();
     },
 
+    _respondBasedOnResultDecorator = function(session, req, result) {
+        //console.log("respondBasedOnResult => "+JSON.stringify(result));
+
+        // Convert string to JSON
+        if (typeof(result) === "string") {
+            try {
+                result = JSON.parse(result);
+            } catch (e) {
+                // In case the conversion fails, report and "Invalid Command Method" error
+                _errors.handleInvalidReqInvalidCommandMethodEH(req, this);
+            }
+        }
+
+        // In case the JSON doesn't contain the expected fields
+        if (result === null ||
+            typeof(result) === "undefined" ||
+            typeof(result) !== "object" ||
+            typeof(result.status) === "undefined" ||
+            typeof(result.value) === "undefined") {
+            _errors.handleFailedCommandEH(
+                _errors.FAILED_CMD_STATUS.UNKNOWN_ERROR,
+                "Command failed without producing the expected error report",
+                req,
+                this,
+                session,
+                "ReqHand");
+        }
+
+        // An error occurred but we got an error report to use
+        if (result.status !== 0) {
+            _errors.handleFailedCommandEH(
+                _errors.FAILED_CMD_STATUS_CODES_NAMES[result.status],
+                result.value.message,
+                req,
+                this,
+                session,
+                "ReqHand");
+        }
+
+        // If we arrive here, everything should be fine, birds are singing, the sky is blue
+        this.success(session.getId(), result.value);
+    },
+
     _decorateResponse = function(response) {
         response.setHeader("Cache", "no-cache");
         response.setHeader("Content-Type", "application/json;charset=UTF-8");
@@ -91,6 +134,7 @@ ghostdriver.RequestHandler = function() {
         response.writeJSON = _writeJSONDecorator;
         response.writeJSONAndClose = _writeJSONAndCloseDecorator;
         response.success = _successDecorator;
+        response.respondBasedOnResult = _respondBasedOnResultDecorator;
     },
 
     _buildResponseBody = function(sessionId, value, statusCode) {

--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -150,48 +150,6 @@ ghostdriver.SessionReqHand = function(session) {
         };
     },
 
-    _respondBasedOnResult = function(req, res, result) {
-        // console.log("respondBasedOnResult => "+JSON.stringify(result));
-
-        // Convert string to JSON
-        if (typeof(result) === "string") {
-            try {
-                result = JSON.parse(result);
-            } catch (e) {
-                // In case the conversion fails, report and "Invalid Command Method" error
-                _erros.handleInvalidReqInvalidCommandMethodEH(req, res);
-            }
-        }
-
-        // In case the JSON doesn't contain the expected fields
-        if (result === null ||
-            typeof(result) === "undefined" ||
-            typeof(result) !== "object" ||
-            typeof(result.status) === "undefined" ||
-            typeof(result.value) === "undefined") {
-            _errors.handleFailedCommandEH(
-                _errors.FAILED_CMD_STATUS.UNKNOWN_ERROR,
-                "Command failed without producing the expected error report",
-                req,
-                res,
-                _session,
-                "SessionReqHand");
-        }
-
-        // An error occurred but we got an error report to use
-        if (result.status !== 0) {
-            _errors.handleFailedCommandEH(
-                _errors.FAILED_CMD_STATUS_CODES_NAMES[result.status],
-                result.value.message,
-                req,
-                res,
-                _session,
-                "SessionReqHand");
-        }
-
-        // If we arrive here, everything should be fine, birds are singing, the sky is blue
-        res.success(_session.getId(), result.value);
-    },
 
     _refreshCommand = function(req, res) {
         var successHand = _createOnSuccessHandler(res);
@@ -253,7 +211,7 @@ ghostdriver.SessionReqHand = function(session) {
 
             // Respond with result ONLY if this hasn't ALREADY timed-out
             if (!timedOut) {
-                _respondBasedOnResult(req, res, result);
+                res.respondBasedOnResult(_session, req, result);
             }
         } else {
             throw _errors.createInvalidReqMissingCommandParameterEH(req);
@@ -265,7 +223,7 @@ ghostdriver.SessionReqHand = function(session) {
 
         if (typeof(postObj) === "object" && postObj.script && postObj.args) {
             _session.getCurrentWindow().setOneShotCallback("onCallback", function() {
-                _respondBasedOnResult(req, res, arguments[0]);
+                res.respondBasedOnResult(_session, req, arguments[0]);
             });
 
             _session.getCurrentWindow().evaluate(
@@ -301,7 +259,7 @@ ghostdriver.SessionReqHand = function(session) {
             "return location.toString()",
             []);
 
-        _respondBasedOnResult(req, res, result);
+        res.respondBasedOnResult(_session, res, result);
     },
 
     _postUrlCommand = function(req, res) {

--- a/src/request_handlers/webelement_request_handler.js
+++ b/src/request_handlers/webelement_request_handler.js
@@ -64,9 +64,7 @@ ghostdriver.WebElementReqHand = function(id, session) {
     _getDisplayedCommand = function(req, res) {
         var isDisplayedAtom = require("./webdriver_atoms.js").get("is_displayed");
         var displayed = _session.getCurrentWindow().evaluate(isDisplayedAtom, _getJSON());
-        displayed = JSON.parse(displayed).value;
-        res.success(_session.getId(), displayed);
-        // TODO handle StaleElementReference
+        res.respondBasedOnResult(_session, req, displayed);
     },
 
     _valueCommand = function(req, res) {


### PR DESCRIPTION
Hi, here's a modified pull request with the two methods indicated.

Commands implemented here:

```
GET /session/:id/source
DELETE /session/:id/cookie
GET /session/:id/element/:id/displayed
```
