### PR TITLE
Set correct length in Content-Length header

### DIFF
--- a/src/request_handlers/request_handler.js
+++ b/src/request_handlers/request_handler.js
@@ -73,14 +73,14 @@ ghostdriver.RequestHandler = function() {
     },
 
     _writeAndCloseDecorator = function(body) {
-        this.setHeader("Content-Length", body.length);
+        this.setHeader("Content-Length", unescape(encodeURIComponent(body)).length);
         this.write(body);
         this.close();
     },
 
     _writeJSONAndCloseDecorator = function(obj) {
         var objStr = JSON.stringify(obj);
-        this.setHeader("Content-Length", objStr.length);
+        this.setHeader("Content-Length", unescape(encodeURIComponent(objStr)).length);
         this.write(objStr);
         this.close();
     },


### PR DESCRIPTION
When dealing with multibyte character strings, String.length returns
length of string in characters, not in bytes. So answer is truncated:

``` shell
sw@etgc ~ $ GET http://localhost:8080/session/1/title
{"sessionId":"1","status":0,"value":"Янде%
sw@etgc ~ $
```

To get byte length we encode and unescape it into one-byte
character Latin-1 encoding.

``` javascript
this.setHeader("Content-Length", unescape(encodeURIComponent(body)).length);
```

NodeJS has Buffer to do that, future HTML5 spec has a Blob constructor but latest WebKit only has a deprecated WebKitBlobBuilder.
