### PR TITLE
Partially implemented cookie commands

### DIFF
--- a/test/build.gradle
+++ b/test/build.gradle
@@ -17,6 +17,7 @@ dependencies {
         testCompile "org.seleniumhq.selenium:$it:$seleniumVersion"
     }
     testCompile "junit:junit-dep:4.8+"
+	testCompile "org.mortbay.jetty:jetty:6.1.21"
 }
 
 tasks.withType(JavaExec) {

--- a/test/src/test/java/ghostdriver/BaseTestWithServer.java
+++ b/test/src/test/java/ghostdriver/BaseTestWithServer.java
@@ -1,0 +1,20 @@
+package ghostdriver;
+
+import ghostdriver.server.CallbackHttpServer;
+import org.junit.After;
+import org.junit.Before;
+
+abstract public class BaseTestWithServer extends BaseTest {
+    protected CallbackHttpServer server;
+
+    @Before
+    public void startServer() throws Exception {
+        server = new CallbackHttpServer();
+        server.start();
+    }
+
+    @After
+    public void stopServer() throws Exception {
+        server.stop();
+    }
+}

--- a/test/src/test/java/ghostdriver/CookiesTest.java
+++ b/test/src/test/java/ghostdriver/CookiesTest.java
@@ -1,0 +1,128 @@
+package ghostdriver;
+
+import static junit.framework.Assert.assertEquals;
+import ghostdriver.server.EmptyPageHttpRequestCallback;
+import ghostdriver.server.HttpRequestCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CookiesTest extends BaseTestWithServer {
+    private WebDriver driver;
+
+    private final static HttpRequestCallback COOKIE_SETTING_CALLBACK = new EmptyPageHttpRequestCallback() {
+        @Override
+        public void call(HttpServletRequest req, HttpServletResponse res) throws IOException {
+            super.call(req, res);
+            res.addCookie(new javax.servlet.http.Cookie("test", "test"));
+            res.addCookie(new javax.servlet.http.Cookie("test2", "test2"));
+        }
+    };
+
+    private final static HttpRequestCallback EMPTY_CALLBACK = new EmptyPageHttpRequestCallback();
+
+    @Before
+    public void setup() {
+        driver = getDriver();
+    }
+
+    private void goToPage() {
+        driver.get(server.getBaseUrl());
+    }
+
+    private Cookie[] getCookies() {
+        return driver.manage().getCookies().toArray(new Cookie[]{});
+    }
+
+    @Test
+    public void gettingAllCookies() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+        Cookie[] cookies = getCookies();
+
+        assertEquals(2, cookies.length);
+        assertEquals("test", cookies[0].getName());
+        assertEquals("test", cookies[0].getValue());
+        assertEquals("localhost", cookies[0].getDomain());
+        assertEquals("/", cookies[0].getPath());
+        assertEquals(false, cookies[0].isSecure());
+        assertEquals("test2", cookies[1].getName());
+        assertEquals("test2", cookies[1].getValue());
+        assertEquals("localhost", cookies[1].getDomain());
+        assertEquals("/", cookies[1].getPath());
+        assertEquals(false, cookies[1].isSecure());
+    }
+
+    @Test
+    public void deletingAllCookies() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+        driver.manage().deleteAllCookies();
+
+        assertEquals(0, getCookies().length);
+
+        server.setGetHandler(EMPTY_CALLBACK);
+        goToPage();
+        assertEquals(0, getCookies().length);
+    }
+
+    @Test
+    public void deletingOneCookie() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+
+        driver.manage().deleteCookieNamed("test");
+
+        Cookie[] cookies = getCookies();
+
+        assertEquals(1, cookies.length);
+        assertEquals("test2", cookies[0].getName());
+
+        server.setGetHandler(EMPTY_CALLBACK);
+        goToPage();
+        assertEquals(1, getCookies().length);
+    }
+
+    @Test
+    public void addingACookie() {
+        server.setGetHandler(EMPTY_CALLBACK);
+        goToPage();
+
+        driver.manage().addCookie(new Cookie("newCookie", "newValue"));
+
+        Cookie[] cookies = getCookies();
+        assertEquals(1, cookies.length);
+        assertEquals("newCookie", cookies[0].getName());
+        assertEquals("newValue", cookies[0].getValue());
+        assertEquals("localhost", cookies[0].getDomain());
+        assertEquals("/", cookies[0].getPath());
+        assertEquals(false, cookies[0].isSecure());
+    }
+
+    @Test
+    public void modifyingACookie() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+
+        driver.manage().addCookie(new Cookie("test", "newValue", "localhost", "/", null, true));
+
+        Cookie[] cookies = getCookies();
+        assertEquals(2, cookies.length);
+        assertEquals("test", cookies[0].getName());
+        assertEquals("newValue", cookies[0].getValue());
+        assertEquals("localhost", cookies[0].getDomain());
+        assertEquals("/", cookies[0].getPath());
+        assertEquals(true, cookies[0].isSecure());
+
+        assertEquals("test2", cookies[1].getName());
+        assertEquals("test2", cookies[1].getValue());
+        assertEquals("localhost", cookies[1].getDomain());
+        assertEquals("/", cookies[1].getPath());
+        assertEquals(false, cookies[1].isSecure());
+    }
+}

--- a/test/src/test/java/ghostdriver/server/CallbackHttpServer.java
+++ b/test/src/test/java/ghostdriver/server/CallbackHttpServer.java
@@ -1,0 +1,43 @@
+package ghostdriver.server;
+
+import static java.lang.String.format;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.Context;
+import org.mortbay.jetty.servlet.ServletHolder;
+
+public class CallbackHttpServer {
+    protected Server server;
+
+    public HttpRequestCallback getGetHandler() {
+        return getHandler;
+    }
+
+    public void setGetHandler(HttpRequestCallback getHandler) {
+        this.getHandler = getHandler;
+    }
+
+    protected HttpRequestCallback getHandler;
+
+    public void start() throws Exception {
+        server = new Server(0);
+        Context context = new Context(server, "/");
+        addServlets(context);
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+
+    protected void addServlets(Context context) {
+        context.addServlet(new ServletHolder(new CallbackServlet(this)), "/*");
+    }
+
+    public int getPort() {
+        return server.getConnectors()[0].getLocalPort();
+    }
+
+    public String getBaseUrl() {
+        return format("http://localhost:%d/", getPort());
+    }
+}

--- a/test/src/test/java/ghostdriver/server/CallbackServlet.java
+++ b/test/src/test/java/ghostdriver/server/CallbackServlet.java
@@ -1,0 +1,23 @@
+package ghostdriver.server;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CallbackServlet extends HttpServlet {
+    private CallbackHttpServer server;
+
+    CallbackServlet(CallbackHttpServer server) {
+        this.server = server;
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        if (server.getGetHandler() != null) {
+            server.getGetHandler().call(req, res);
+        } else {
+            super.doGet(req, res);
+        }
+    }
+}

--- a/test/src/test/java/ghostdriver/server/EmptyPageHttpRequestCallback.java
+++ b/test/src/test/java/ghostdriver/server/EmptyPageHttpRequestCallback.java
@@ -1,0 +1,12 @@
+package ghostdriver.server;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class EmptyPageHttpRequestCallback implements HttpRequestCallback {
+    @Override
+    public void call(HttpServletRequest req, HttpServletResponse res) throws IOException {
+        res.getOutputStream().println("<html><head></head><body></body></html>");
+    }
+}

--- a/test/src/test/java/ghostdriver/server/HttpRequestCallback.java
+++ b/test/src/test/java/ghostdriver/server/HttpRequestCallback.java
@@ -1,0 +1,9 @@
+package ghostdriver.server;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public interface HttpRequestCallback {
+    void call(HttpServletRequest req, HttpServletResponse res) throws IOException;
+}


### PR DESCRIPTION
This pull request contains a slightly incomplete implementation of all cookie related commands of webdriver protocol. The main feature missing is handling of cookie expiry dates - this is due to the fact that phantomjs currently stores them as strings making it almost impossible (ok, more of a PITA actually) to parse/encode them with pure js and I didn't want to pull a lib just for that cause I believe that this should be made easier in phantomjs. Probably writing some more tests around cookie path, secure and domain properties would be feasible as well.

This pull request contains a test class that uses all of the cookie related commands of webdriver. It also contains a mechanism (copied from Geb's internal test suite) for setting up a callback in-memory server that serves test pages. It seemed to be the only way to go to get proper coverage for cookie related stuff. It will also allow to modify tests that currently depend on external services like google, yahoo, bing etc. to use a local server to make them more future-proof. Have a look at CookiesTest and classes in the new ghostdriver.server package to learn how to use it.

Please let me know if there is something that I should improve to get that pull request accepted.
