### PR TITLE
fix mouse click position

### DIFF
--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -31,6 +31,7 @@ var ghostdriver = ghostdriver || {};
 ghostdriver.SessionReqHand = function(session) {
     // private:
     var
+    _mousePos = {x: 0, y: 0},
     _protoParent = ghostdriver.SessionReqHand.prototype,
     _session = session,
     _locator = new ghostdriver.WebElementLocator(_session),
@@ -568,6 +569,7 @@ ghostdriver.SessionReqHand = function(session) {
 
             // Send the Mouse Move as native event
             _session.getCurrentWindow().sendEvent("mousemove", coords.x, coords.y);
+	    _mousePos = { x: coords.x, y: coords.y };
             res.success(_session.getId());
         } else {
             // Neither "element" nor "xoffset/yoffset" were provided
@@ -590,7 +592,7 @@ ghostdriver.SessionReqHand = function(session) {
             }
             // Send the Mouse Click as native event
             _session.getCurrentWindow().sendEvent(clickType,
-                0, 0, //< x, y
+                _mousePos.x, _mousePos.y, //< x, y
                 mouseButton);
             res.success(_session.getId());
         } else {


### PR DESCRIPTION
I'm using the ruby selenium-webdriver gem 2.25 and with that it seems that the mouse clicks are always done on coords 0, 0 and not in the place where the mouse has been moved to previously. Am I correct?

I've include a hack that seems to fix it for me atleast.
