### PR TITLE
Allowing empty strings for JSON body of mouse click events.

### DIFF
--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -576,10 +576,15 @@ ghostdriver.SessionReqHand = function(session) {
     },
 
     _postMouseClickCommand = function(req, res, clickType) {
-        var postObj = JSON.parse(req.post),
+        var postObj = {},
             mouseButton = "left";
         // normalize click
         clickType = clickType || "click";
+
+        // The protocol allows language bindings to send an empty string
+        if (req.post.length > 0) {
+            postObj = JSON.parse(req.post);
+        }
 
         // Check that either an Element ID or an X-Y Offset was provided
         if (typeof(postObj) === "object") {


### PR DESCRIPTION
The JSON wire protocol says that for the /session/:sessionId/click endpoint, the "button" JSON parameter may be omitted. It does not specify whether an empty JSON object must be sent, or if the body of the HTTP request can be left empty. Some language bindings leave the body empty, and a server implementation must account for that.
