### PR TITLE
Added failing test for frame switching.

### DIFF
--- a/test/src/test/java/ghostdriver/FrameSwitchingTest.java
+++ b/test/src/test/java/ghostdriver/FrameSwitchingTest.java
@@ -1,6 +1,9 @@
 package ghostdriver;
 
+import java.lang.Thread;
+import java.lang.InterruptedException;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchFrameException;
 import org.openqa.selenium.WebDriver;
@@ -38,5 +41,35 @@ public class FrameSwitchingTest extends BaseTest {
         WebDriver d = getDriver();
         d.get("http://docs.wpm.neustar.biz/testscript-api/index.html");
         d.switchTo().frame("unavailable frame");
+    }
+
+	@Test
+    public void testShouldBeAbleToClickInAFrame() throws InterruptedException {
+        WebDriver d = getDriver();
+        
+		d.get("http://docs.wpm.neustar.biz/testscript-api/index.html");
+        d.switchTo().frame("classFrame");
+
+        // This should replace frame "classFrame" ...
+        d.findElement(By.linkText("HttpClient")).click();
+
+		// To avoid a dependency on WebDriverWait, we will hard-code a
+		// sleep for now.
+		Thread.sleep(2000);
+
+        // driver should still be focused on frame "classFrame" ...
+		String text = d.findElement(By.linkText("clearCookies")).getText();
+        assertEquals("clearCookies", text);
+        
+		// Make sure it was really frame "classFrame" which was replaced ...
+        d.switchTo().defaultContent().switchTo().frame("classFrame");
+
+		// To avoid a dependency on WebDriverWait, we will hard-code a
+		// sleep for now.
+		Thread.sleep(2000);
+
+		// Reverify the text
+		text = d.findElement(By.linkText("clearCookies")).getText();
+        assertEquals("clearCookies", text);
     }
 }


### PR DESCRIPTION
This pull request contains nothing more than a failing test for frame switching. It is pretty much cribbed from the WebDriver FrameSwitchingTest.java. I've tried my level best to debug the issue, but the architecture eludes me. Yes, the test has a hard-coded sleep, appropriately commented. The test should be modified to remove the sleep when it's finally enabled as part of the long-term test suite.
