### PR TITLE
Cookies API has .cookie as a property

### DIFF
--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -623,7 +623,7 @@ ghostdriver.SessionReqHand = function(session) {
     },
 
     _getCookieCommand = function(req, res) {
-        var allCookies = _session.getCurrentWindow().cookies();
+        var allCookies = _session.getCurrentWindow().cookies;
         res.success(_session.getId(), allCookies);
     },
 


### PR DESCRIPTION
Cookies API in PhantomJS has implemented .cookie as a property, not a method.
