### PR TITLE
Adding simple cookie test

### DIFF
--- a/test/src/test/java/ghostdriver/CookieTest.java
+++ b/test/src/test/java/ghostdriver/CookieTest.java
@@ -1,0 +1,22 @@
+package ghostdriver;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.Cookie;
+
+public class CookieTest extends BaseTest {
+    @Test
+    public void shouldBeAbleToAddCookie() {
+        WebDriver d = getDriver();
+        d.get("http://docs.wpm.neustar.biz/testscript-api/index.html");
+
+        d.manage().deleteAllCookies();
+        Cookie myCookie = new Cookie("foo", "bar");
+        d.manage().addCookie(myCookie);
+
+        Set<Cookie> allCookies = d.manage().getCookies();
+        assertEquals(1, allCookies.size());
+    }
+}


### PR DESCRIPTION
This pull request adds CookieTest.java, which at the moment, includes only a simple test to add a cookie through the WebDriver cookies API, and verify that any cookies are set on the test page. 
