### PR TITLE
Improvements to cookie tests and better test coverage for cookie stuff

### DIFF
--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -659,24 +659,12 @@ ghostdriver.SessionReqHand = function(session) {
         var deleted;
         if (req.urlParsed.chunks.length === 2) {
             // delete only 1 cookie among the one visible to this page
-            deleted = _session.getCurrentWindow().deleteCookie(req.urlParsed.chunks[1]);
+            _session.getCurrentWindow().deleteCookie(req.urlParsed.chunks[1]);
         } else {
             // delete all the cookies visible to this page
-            deleted = _session.getCurrentWindow().clearCookies();
+            _session.getCurrentWindow().clearCookies();
         }
-
-        if (deleted) {
-            res.success(_session.getId());
-        } else {
-            // Something went wrong when trying to delete the cookie
-            _errors.handleFailedCommandEH(
-                _errors.FAILED_CMD_STATUS.UNABLE_TO_SET_COOKIE,
-                "Unable to set Cookie",
-                req,
-                res,
-                _session,
-                "SessionReqHand");
-        }
+        res.success(_session.getId());
     },
 
     _deleteWindowCommand = function(req, res) {

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -18,6 +18,7 @@ dependencies {
         testCompile "org.seleniumhq.selenium:$it:$seleniumVersion"
     }
     testCompile "junit:junit-dep:4.8+"
+	testCompile "org.mortbay.jetty:jetty:6.1.21"
 }
 
 tasks.withType(JavaExec) {

--- a/test/src/test/java/ghostdriver/BaseTestWithServer.java
+++ b/test/src/test/java/ghostdriver/BaseTestWithServer.java
@@ -1,0 +1,20 @@
+package ghostdriver;
+
+import ghostdriver.server.CallbackHttpServer;
+import org.junit.After;
+import org.junit.Before;
+
+abstract public class BaseTestWithServer extends BaseTest {
+    protected CallbackHttpServer server;
+
+    @Before
+    public void startServer() throws Exception {
+        server = new CallbackHttpServer();
+        server.start();
+    }
+
+    @After
+    public void stopServer() throws Exception {
+        server.stop();
+    }
+}

--- a/test/src/test/java/ghostdriver/CookieTest.java
+++ b/test/src/test/java/ghostdriver/CookieTest.java
@@ -1,6 +1,12 @@
 package ghostdriver;
 
+import ghostdriver.server.EmptyPageHttpRequestCallback;
+import ghostdriver.server.HttpRequestCallback;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
 import java.util.Date;
 import java.util.Set;
 
@@ -8,56 +14,161 @@ import org.openqa.selenium.InvalidCookieDomainException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.Cookie;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.*;
 
-public class CookieTest extends BaseTest {
-    @Test
-    public void shouldBeAbleToAddCookie() throws InterruptedException {
-        WebDriver d = getDriver();
-        d.get("http://www.github.com");
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-        // Clear all cookies
-        assertTrue(d.manage().getCookies().size() > 0);
-        d.manage().deleteAllCookies();
-        assertEquals(d.manage().getCookies().size(), 0);
+public class CookieTest extends BaseTestWithServer {
+    private WebDriver driver;
 
-        // Add a cookie
-        Cookie myCookie = new Cookie("foo", "bar");
-        d.manage().addCookie(myCookie);
-        assertEquals(d.manage().getCookies().size(), 1);
+    private final static HttpRequestCallback COOKIE_SETTING_CALLBACK = new EmptyPageHttpRequestCallback() {
+        @Override
+        public void call(HttpServletRequest req, HttpServletResponse res) throws IOException {
+            super.call(req, res);
+            javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie("test", "test");
+            cookie.setMaxAge(360);
 
-        // Check that the new cookie it's there
-        Cookie myCookieIsBack = d.manage().getCookieNamed("foo");
-        assertTrue(myCookieIsBack.getDomain().contains("github"));
+            res.addCookie(cookie);
+            res.addCookie(new javax.servlet.http.Cookie("test2", "test2"));
+        }
+    };
+
+    private final static HttpRequestCallback EMPTY_CALLBACK = new EmptyPageHttpRequestCallback();
+
+    @Before
+    public void setup() {
+        driver = getDriver();
     }
 
-	@Test
-    public void shouldRetainCookieInfo() {
-        WebDriver d = getDriver();
-        d.get("https://github.com/");
+    @After
+    public void cleanUp() {
+        driver.manage().deleteAllCookies();
+    }
 
-        // Clear all cookies
-        assertTrue(d.manage().getCookies().size() > 0);
-        d.manage().deleteAllCookies();
-        assertEquals(d.manage().getCookies().size(), 0);
+    private void goToPage(String path) {
+        driver.get(server.getBaseUrl() + path);
+    }
+
+    private void goToPage() {
+        goToPage("");
+    }
+
+    private Cookie[] getCookies() {
+        return driver.manage().getCookies().toArray(new Cookie[]{});
+    }
+
+    @Test
+    public void gettingAllCookies() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+        Cookie[] cookies = getCookies();
+
+        assertEquals(2, cookies.length);
+        assertEquals("test", cookies[0].getName());
+        assertEquals("test", cookies[0].getValue());
+        assertEquals("localhost", cookies[0].getDomain());
+        assertEquals("/", cookies[0].getPath());
+        assertTrue(cookies[0].getExpiry() != null);
+        assertEquals(false, cookies[0].isSecure());
+        assertEquals("test2", cookies[1].getName());
+        assertEquals("test2", cookies[1].getValue());
+        assertEquals("localhost", cookies[1].getDomain());
+        assertEquals("/", cookies[1].getPath());
+        assertEquals(false, cookies[1].isSecure());
+        assertTrue(cookies[1].getExpiry() == null);
+    }
+
+    @Test
+    public void gettingAllCookiesOnANonCookieSettingPage() {
+        server.setGetHandler(EMPTY_CALLBACK);
+        goToPage();
+        assertEquals(0, getCookies().length);
+    }
+
+    @Test
+    public void deletingAllCookies() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+        driver.manage().deleteAllCookies();
+
+        assertEquals(0, getCookies().length);
+    }
+
+    @Test
+    public void deletingOneCookie() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+
+        driver.manage().deleteCookieNamed("test");
+
+        Cookie[] cookies = getCookies();
+
+        assertEquals(1, cookies.length);
+        assertEquals("test2", cookies[0].getName());
+    }
+
+    @Test
+    public void addingACookie() {
+        server.setGetHandler(EMPTY_CALLBACK);
+        goToPage();
+
+        driver.manage().addCookie(new Cookie("newCookie", "newValue"));
+
+        Cookie[] cookies = getCookies();
+        assertEquals(1, cookies.length);
+        assertEquals("newCookie", cookies[0].getName());
+        assertEquals("newValue", cookies[0].getValue());
+        assertEquals("localhost", cookies[0].getDomain());
+        assertEquals("/", cookies[0].getPath());
+        assertEquals(false, cookies[0].isSecure());
+    }
+
+    @Test
+    public void modifyingACookie() {
+        server.setGetHandler(COOKIE_SETTING_CALLBACK);
+        goToPage();
+
+        driver.manage().addCookie(new Cookie("test", "newValue", "localhost", "/", null, false));
+
+        Cookie[] cookies = getCookies();
+        assertEquals(2, cookies.length);
+        assertEquals("test", cookies[0].getName());
+        assertEquals("newValue", cookies[0].getValue());
+        assertEquals("localhost", cookies[0].getDomain());
+        assertEquals("/", cookies[0].getPath());
+        assertEquals(false, cookies[0].isSecure());
+
+        assertEquals("test2", cookies[1].getName());
+        assertEquals("test2", cookies[1].getValue());
+        assertEquals("localhost", cookies[1].getDomain());
+        assertEquals("/", cookies[1].getPath());
+        assertEquals(false, cookies[1].isSecure());
+    }
+
+    @Test
+    public void shouldRetainCookieInfo() {
+        server.setGetHandler(EMPTY_CALLBACK);
+        goToPage();
 
         // Added cookie (in a sub-path - allowed)
         Cookie addedCookie =
             new Cookie.Builder("fish", "cod")
                 .expiresOn(new Date(System.currentTimeMillis() + 100 * 1000)) //< now + 100sec
                 .path("/404")
-                .isSecure(true)
-                .domain("github.com")
+                .domain("localhost")
                 .build();
-        d.manage().addCookie(addedCookie);
+        driver.manage().addCookie(addedCookie);
 
         // Search cookie on the root-path and fail to find it
-        Cookie retrieved = d.manage().getCookieNamed("fish");
+        Cookie retrieved = driver.manage().getCookieNamed("fish");
         assertNull(retrieved);
 
         // Go to the "/404" sub-path (to find the cookie)
-        d.get("https://github.com/404");
-        retrieved = d.manage().getCookieNamed("fish");
+        goToPage("404");
+        retrieved = driver.manage().getCookieNamed("fish");
         assertNotNull(retrieved);
         // Check that it all matches
         assertEquals(addedCookie.getName(), retrieved.getName());
@@ -66,25 +177,19 @@ public class CookieTest extends BaseTest {
         assertEquals(addedCookie.isSecure(), retrieved.isSecure());
         assertEquals(addedCookie.getPath(), retrieved.getPath());
         assertTrue(retrieved.getDomain().contains(addedCookie.getDomain()));
-
-        // Clear cookies
-        d.manage().deleteAllCookies();
-        assertEquals(d.manage().getCookies().size(), 0);
     }
 
     @Test(expected = InvalidCookieDomainException.class)
     public void shouldNotAllowToCreateCookieOnDifferentDomain() {
-        WebDriver d = getDriver();
-        d.get("https://www.google.com/");
+        goToPage();
 
         // Added cookie (in a sub-path)
         Cookie addedCookie =
                 new Cookie.Builder("fish", "cod")
                         .expiresOn(new Date(System.currentTimeMillis() + 100 * 1000)) //< now + 100sec
                         .path("/404")
-                        .isSecure(true)
                         .domain("github.com")
                         .build();
-        d.manage().addCookie(addedCookie);
+        driver.manage().addCookie(addedCookie);
     }
 }

--- a/test/src/test/java/ghostdriver/server/CallbackHttpServer.java
+++ b/test/src/test/java/ghostdriver/server/CallbackHttpServer.java
@@ -1,0 +1,43 @@
+package ghostdriver.server;
+
+import static java.lang.String.format;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.Context;
+import org.mortbay.jetty.servlet.ServletHolder;
+
+public class CallbackHttpServer {
+    protected Server server;
+
+    public HttpRequestCallback getGetHandler() {
+        return getHandler;
+    }
+
+    public void setGetHandler(HttpRequestCallback getHandler) {
+        this.getHandler = getHandler;
+    }
+
+    protected HttpRequestCallback getHandler;
+
+    public void start() throws Exception {
+        server = new Server(0);
+        Context context = new Context(server, "/");
+        addServlets(context);
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+
+    protected void addServlets(Context context) {
+        context.addServlet(new ServletHolder(new CallbackServlet(this)), "/*");
+    }
+
+    public int getPort() {
+        return server.getConnectors()[0].getLocalPort();
+    }
+
+    public String getBaseUrl() {
+        return format("http://localhost:%d/", getPort());
+    }
+}

--- a/test/src/test/java/ghostdriver/server/CallbackServlet.java
+++ b/test/src/test/java/ghostdriver/server/CallbackServlet.java
@@ -1,0 +1,23 @@
+package ghostdriver.server;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CallbackServlet extends HttpServlet {
+    private CallbackHttpServer server;
+
+    CallbackServlet(CallbackHttpServer server) {
+        this.server = server;
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        if (server.getGetHandler() != null) {
+            server.getGetHandler().call(req, res);
+        } else {
+            super.doGet(req, res);
+        }
+    }
+}

--- a/test/src/test/java/ghostdriver/server/EmptyPageHttpRequestCallback.java
+++ b/test/src/test/java/ghostdriver/server/EmptyPageHttpRequestCallback.java
@@ -1,0 +1,12 @@
+package ghostdriver.server;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class EmptyPageHttpRequestCallback implements HttpRequestCallback {
+    @Override
+    public void call(HttpServletRequest req, HttpServletResponse res) throws IOException {
+        res.getOutputStream().println("<html><head></head><body></body></html>");
+    }
+}

--- a/test/src/test/java/ghostdriver/server/HttpRequestCallback.java
+++ b/test/src/test/java/ghostdriver/server/HttpRequestCallback.java
@@ -1,0 +1,9 @@
+package ghostdriver.server;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public interface HttpRequestCallback {
+    void call(HttpServletRequest req, HttpServletResponse res) throws IOException;
+}


### PR DESCRIPTION
This pull request contains  improvements to cookie tests and test coverage to cookie related code.

Please note that `modifyingACookie()` test fails for ghostdriver but not for firefox driver. I believe that this means that there is a bug in the implementation of cookie handling in ghostrdriver, please feel free to fix it on your own;).

It also contains contains a mechanism (copied from Geb's internal test suite) for setting up a callback in-memory server that serves test pages that I tried to contribute in my previous pull request. Have a look at CookieTest and classes in the new ghostdriver.server package to learn how to use it.
