### PR TITLE
Make it possible to run tests with firefox driver without changing the code

### DIFF
--- a/test/build.gradle
+++ b/test/build.gradle
@@ -38,4 +38,8 @@ test {
     onOutput { descriptor, event ->
         logger.lifecycle("Test: " + descriptor + " produced standard out/err: " + event.message )
     }
+
+	if (project.hasProperty('driver')) {
+		systemProperty 'ghostdriver.test.driver', project.driver
+	}
 }

--- a/test/src/test/java/ghostdriver/BaseTest.java
+++ b/test/src/test/java/ghostdriver/BaseTest.java
@@ -22,8 +22,11 @@ public abstract class BaseTest {
     {
         DesiredCapabilities capabilities = new DesiredCapabilities();
         capabilities.setJavascriptEnabled(true);
-        mDriver = new RemoteWebDriver(new URL(GHOSTDRIVER_URL), capabilities);
-//        mDriver = new FirefoxDriver(capabilities);
+        if (System.getProperty("ghostdriver.test.driver", "").equals("firefox")) {
+            mDriver = new FirefoxDriver(capabilities);
+        } else {
+            mDriver = new RemoteWebDriver(new URL(GHOSTDRIVER_URL), capabilities);
+        }
     }
 
     protected WebDriver getDriver() {


### PR DESCRIPTION
Thanks to that you can now run tests with firefox driver from command line using:

```
./gradlew test -Pdriver=firefox
```
