### PR TITLE
Executing async JavaScript crashes PhantomJS

### DIFF
--- a/test/src/test/java/ghostdriver/ScriptExecutionTest.java
+++ b/test/src/test/java/ghostdriver/ScriptExecutionTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -28,5 +29,18 @@ public class ScriptExecutionTest extends BaseTest {
                 "window.setTimeout(arguments[arguments.length - 1], arguments[0], 'done');",
                 1000);
         assertEquals("done", res);
+    }
+
+    @Test
+    public void shouldBeAbleToPassMultipleArgumentsToAsyncScripts() {
+        WebDriver d = getDriver();
+        d.manage().timeouts().setScriptTimeout(0, TimeUnit.MILLISECONDS);
+        d.get("http://www.google.com/");
+        Number result = (Number) ((JavascriptExecutor) d)
+            .executeAsyncScript("arguments[arguments.length - 1](arguments[0] + arguments[1]);", 1, 2);
+        assertEquals(3, result.intValue());
+
+        // Verify that a future navigation does not cause the driver to have problems.
+        d.get("http://www.google.com/");
     }
 }


### PR DESCRIPTION
Executing JavaScript asynchronously crashes PhantomJS upon the next navigation. This pull request contains a failing test which reproduces the crash.
