### PR TITLE
Navigation back/forward with no history crashes PhantomJS

### DIFF
--- a/test/src/test/java/ghostdriver/NavigationTest.java
+++ b/test/src/test/java/ghostdriver/NavigationTest.java
@@ -24,4 +24,18 @@ public class NavigationTest extends BaseTest {
         d.navigate().forward();
         assertTrue(d.getTitle().toLowerCase().contains("HTML5".toLowerCase()));
     }
+
+    @Test
+    public void navigateBackWithNoHistory() throws Exception {
+        // Quit the existing driver, and create a brand-new fresh
+        // one to insure we have no history.
+        quitDriver();
+        prepareDriver();
+        WebDriver d = getDriver();
+        d.navigate().back();
+        d.navigate().forward();
+
+        // Make sure explicit navigation still works.
+        d.get("http://google.com");
+    }
 }


### PR DESCRIPTION
On a fresh instance of PhantomJS, with no history entries, navigating back and forward, causes PhantomJS to crash upon the next direct navigation to a URL.
