### PR TITLE
getPageSource should return source of current frame

### DIFF
--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -541,7 +541,7 @@ ghostdriver.SessionReqHand = function(session) {
     },
 
     _getSourceCommand = function(req, res) {
-        var source = _session.getCurrentWindow().content;
+        var source = _session.getCurrentWindow().frameContent;
         res.success(_session.getId(), source);
     },
 

--- a/test/src/test/java/ghostdriver/FrameSwitchingTest.java
+++ b/test/src/test/java/ghostdriver/FrameSwitchingTest.java
@@ -152,4 +152,20 @@ public class FrameSwitchingTest extends BaseTest {
         d.switchTo().defaultContent();
         assertEquals(topLevelTitle, d.getTitle());
     }
+
+    @Test
+    public void pageSourceShouldReturnSourceOfFocusedFrame() throws InterruptedException {
+        WebDriver d = getDriver();
+        d.get("http://docs.wpm.neustar.biz/testscript-api/index.html");
+
+        String pageSource = d.getPageSource();
+        // Wait for new content to load in the frame.
+        // To avoid a dependency on WebDriverWait, we will hard-code a sleep for now.
+        Thread.sleep(2000);
+
+        d.switchTo().frame("classFrame");
+        String framePageSource = d.getPageSource();
+        assertFalse(pageSource.equals(framePageSource));
+        assertTrue("Page source was: " + framePageSource, framePageSource.contains("Interface Summary"));
+    }
 }


### PR DESCRIPTION
getPageSource command should return the HTML source of the current frame, not always the top-level page.
