### PR TITLE
Unexpected error executing sequential async scripts

### DIFF
--- a/test/src/test/java/ghostdriver/ScriptExecutionTest.java
+++ b/test/src/test/java/ghostdriver/ScriptExecutionTest.java
@@ -43,4 +43,15 @@ public class ScriptExecutionTest extends BaseTest {
         // Verify that a future navigation does not cause the driver to have problems.
         d.get("http://www.google.com/");
     }
+
+    @Test
+    public void shouldBeAbleToExecuteMultipleAsyncScriptsSequentially() {
+        WebDriver d = getDriver();
+        d.manage().timeouts().setScriptTimeout(0, TimeUnit.MILLISECONDS);
+        d.get("http://www.google.com/");
+		Number numericResult = (Number) ((JavascriptExecutor) d).executeAsyncScript("arguments[arguments.length - 1](123);");
+        assertEquals(123, numericResult.intValue());
+		String stringResult = (String) ((JavascriptExecutor) d).executeAsyncScript("arguments[arguments.length - 1]('abc');");
+        assertEquals("abc", stringResult);
+    }
 }


### PR DESCRIPTION
When executing multiple scripts sequentially using JavascriptExecutor.executeAsyncScript(), you receive an unexpected error on any script after the first. The error is:

```
"cannot access member `statusCode' of deleted QObject"
```
