### PR TITLE
Guarding against improper post data in getActiveElement

### DIFF
--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -745,7 +745,7 @@ ghostdriver.SessionReqHand = function(session) {
 
         // Some language bindings can send a null instead of an empty
         // JSON object for the getActiveElement command.
-        if (req.post) {
+        if (req.post && typeof req.post === "string") {
             request = JSON.parse(req.post);
         }
 


### PR DESCRIPTION
The req.post value can in some cases not be a string, so JSON.parse will throw. This fix guards against that possibility.
