### PR TITLE
Using the correct atom for the getCssPropertyValue command

### DIFF
--- a/src/request_handlers/webelement_request_handler.js
+++ b/src/request_handlers/webelement_request_handler.js
@@ -325,9 +325,9 @@ ghostdriver.WebElementReqHand = function(idOrElement, session) {
         // Check that a property name was indeed provided
         if (typeof(cssPropertyName) === "string" || cssPropertyName.length > 0) {
             result = _protoParent.getSessionCurrWindow.call(this, req).evaluate(
-                require("./webdriver_atoms.js").get("execute_script"),
-                "return window.getComputedStyle(arguments[0]).getPropertyValue(arguments[1]);",
-                [_getJSON(), cssPropertyName]);
+                require("./webdriver_atoms.js").get("get_value_of_css_property"),
+                _getJSON(),
+                cssPropertyName);
 
             res.respondBasedOnResult(_session, req, result);
             return;


### PR DESCRIPTION
There is already an injectable atom for getting the value of a CSS property. We should use it rather than calling execute_script for a different atom.
