### PR TITLE
Normalizing common character aliases for sendKeys

### DIFF
--- a/src/request_handlers/webelement_request_handler.js
+++ b/src/request_handlers/webelement_request_handler.js
@@ -213,11 +213,15 @@ ghostdriver.WebElementReqHand = function(idOrElement, session) {
 
         // Ensure all required parameters are available
         if (typeof(postObj) === "object" && typeof(postObj.value) === "object") {
+            var text = postObj.value.join("");
+            text = text.replace(/[\b]/g, '\uE003').           // Backspace
+                        replace(/\t/g, '\uE004').             // Tab
+                        replace(/(\r\n|\n|\r)/g, '\uE006');   // Return
             // Execute the "type" atom
             typeRes = _protoParent.getSessionCurrWindow.call(this, _session, req).evaluate(
                 typeAtom,
                 _getJSON(),
-                postObj.value);
+                text.split(""));
 
             res.respondBasedOnResult(_session, req, typeRes);
             return;


### PR DESCRIPTION
Certain keystrokes should be normalized when using sendKeys. Among them are `\r`, `\n`, `\r\n`, `\t`, and `\b`. This pull request normalizes occurrences of those aliases to their correct Unicode WebDriver representations before passing them to the type automation atom.
