### PR TITLE
Submitting a form by clicking on input[type=submit] seems not to work

### DIFF
--- a/test/java/src/test/java/ghostdriver/FormSubmitTest.java
+++ b/test/java/src/test/java/ghostdriver/FormSubmitTest.java
@@ -1,0 +1,60 @@
+/*
+This file is part of the GhostDriver project from Neustar inc.
+
+Copyright (c) 2012, Ivan De Marino <ivan.de.marino@gmail.com / detronizator@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package ghostdriver;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class FormSubmitTest extends BaseTest {
+    @Test
+    public void itShouldSubmitFormWhenSubmitButtonIsClicked() {
+        String strToSearchFor = "beer";
+        WebDriver d = getDriver();
+
+        // Load Amazon.com
+        d.get("http://amazon.de");
+        // amazon search bar
+        WebElement textField = d.findElement(By.id("twotabsearchtextbox"));
+        
+        //Submit button on amazon.com
+        WebElement submitButton = d.findElement(By.className("nav-submit-input"));
+        
+        // Type beer
+        textField.sendKeys(strToSearchFor);
+        
+        //submit the form
+        submitButton.click();
+
+        // Check results contains the term we searched for
+        assertTrue(d.getTitle().toLowerCase().contains(strToSearchFor.toLowerCase()));
+    }
+}


### PR DESCRIPTION
As the headline says, submitting forms by clicking submit buttons, does not seem to work.

I would have tried to write a java test, but the test suite seems to be broken atm. (#93 ?)
Instead a wrote a small ruby cucumber test to demonstrate what I mean.

```
Scenario: Go to Amazon
  When I visit Amazon
  And I enter a beer
  Then the title should include beer
```

Implementation (using watir)

```
When /^I visit Amazon$/ do
  @browser.goto "http://amazon.com"
end

When /^I enter a beer$/ do
  @browser.text_field(:id, "twotabsearchtextbox").set "beer"
  @browser.input(:class, "nav-submit-input").click
end

Then /^the title should include beer$/ do
   @browser.title.should include "beer"
end
```

This code workfs flawlessly in Firefox, but not in Ghostdriver. 
Submitting the form directly (triggering submit on it) seems to work, but is not my preferred solution.

I tried to figure out, how Ghostdriver is working, but ended up with finding click events handles in an minified webdriver_atom, I couldn't debug in a trice.

If you have any questions, just go on.

Btw: Thanks a lot for your awesome work :)
