### PR TITLE
Adding async script test which crashes PhantomJS

### DIFF
--- a/test/java/src/test/java/ghostdriver/ScriptExecutionTest.java
+++ b/test/java/src/test/java/ghostdriver/ScriptExecutionTest.java
@@ -85,4 +85,23 @@ public class ScriptExecutionTest extends BaseTest {
                 "arguments[arguments.length - 1]('abc');");
         assertEquals("abc", stringResult);
     }
+
+    @Test
+    public void shouldBeAbleToExecuteMultipleAsyncScriptsSequentiallyWithNavigation() {
+        WebDriver d = getDriver();
+        d.manage().timeouts().setScriptTimeout(0, TimeUnit.MILLISECONDS);
+
+        d.get("http://www.google.com/");
+        Number numericResult = (Number) ((JavascriptExecutor) d).executeAsyncScript(
+                "arguments[arguments.length - 1](123);");
+        assertEquals(123, numericResult.intValue());
+
+        d.get("http://www.google.com/");
+        String stringResult = (String) ((JavascriptExecutor) d).executeAsyncScript(
+                "arguments[arguments.length - 1]('abc');");
+        assertEquals("abc", stringResult);
+
+        // Verify that a future navigation does not cause the driver to have problems.
+        d.get("http://www.google.com/");
+    }
 }


### PR DESCRIPTION
Executing asynchronous scripts was broken by the commit to handle fragment navigation (https://github.com/detro/ghostdriver/commit/e66eb0a9aa26ea87f9829dd4f480abfa6e6de494). Executing sequential asynchronous scripts with navigation in between fails on the third such navigation, crashing PhantomJS. This pull request supplies a test which reproduces the issue.
