### PR TITLE
Set Capability browserVersion to return only the PhantomJS version

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -32,9 +32,7 @@ ghostdriver.Session = function(desiredCapabilities) {
     var
     _defaultCapabilities = {    // TODO - Actually try to match the "desiredCapabilities" instead of ignoring them
         "browserName" : "phantomjs",
-        "version" :
-            "phantomjs-" + phantom.version.major + '.' + phantom.version.minor + '.' + phantom.version.patch + '+' +
-            "ghostdriver-" + ghostdriver.version,
+        "version" : phantom.version.major + '.' + phantom.version.minor + '.' + phantom.version.patch,
         "platform" : ghostdriver.system.os.name + '-' + ghostdriver.system.os.version + '-' + ghostdriver.system.os.architecture,
         "javascriptEnabled" : true,
         "takesScreenshot" : true,


### PR DESCRIPTION
With this pull request, only the PhantomJS version information is returned.  This will allow for consumers of the version value to be able to parse it without having to perform additional string manipulations to strip out the text and GhostDriver version information.

A specific example of this for .NET would be reading the version value into the .NET Version class, which can automatically parse version information, given a version string delimited by '.'

This behavior will then be consistent across with the other driver implementations, as Chrome, Firefox, and IE return only the browser version.
