### PR TITLE
Fixed sendKeys("\n"), for compatibility with other browser, is an enter key in ghostdriver is a return key

### DIFF
--- a/src/inputs.js
+++ b/src/inputs.js
@@ -40,7 +40,7 @@ ghostdriver.Inputs = function () {
         '\uE004': "Tab",           // Tab
         '\uE005': "Clear",         // Clear
         '\uE006': "\n",
-        '\uE007': "\n",
+        '\uE007': "Enter",
         '\uE008': "Shift",         // Shift
         '\uE009': "Control",       // Control
         '\uE00A': "Alt",           // Alt
@@ -261,12 +261,13 @@ ghostdriver.Inputs = function () {
     },
 
     _translateKey = function (session, key) {
-        var actualKey = key;
-        var phantomjskeys = session.getCurrentWindow().event.key;
+        var
+            actualKey = key,
+            phantomjskeys = session.getCurrentWindow().event.key;
         if (_specialKeys.hasOwnProperty(key)) {
             actualKey = _specialKeys[key];
-            if (session.getCurrentWindow().event.key.hasOwnProperty(actualKey)) {
-                actualKey = session.getCurrentWindow().event.key[actualKey];
+            if (phantomjskeys.hasOwnProperty(actualKey)) {
+                actualKey = phantomjskeys[actualKey];
             }
         }
         return actualKey;

--- a/src/request_handlers/webelement_request_handler.js
+++ b/src/request_handlers/webelement_request_handler.js
@@ -236,7 +236,7 @@ ghostdriver.WebElementReqHand = function(idOrElement, session) {
                     }
                     break;
                 case '\n':
-                    resultStr += '\uE006';  // Return
+                    resultStr += '\uE007';  // Enter
                     break;
                 default:
                     resultStr += str[i];


### PR DESCRIPTION
**test.html**

``` html
<!DOCTYPE html>
<html>
  <head>
    <title>Input enter</title>
    <style type="text/css">
      * {
        margin: 0;
        padding: 0;
        border: 0;
        outline: 0;
      }
      body {
        font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
        text-align: center;
      }
      a {
        color: #00b7ff;
      }
      input {
        border: 1px solid #f00;
        width: 300px;
        height: 25px;
        margin-top: 20px;
        padding: 2px;
      }
    </style>
  </head>
  <body>
    <form>
      <input type="text" id="text">
      <select id="select">
        <option value="a">A</option>
        <option value="b">B</option>
        <option value="c">C</option>
      </select>
      <textarea id="textarea"></textarea>
    </form>
    <div id="div">HOLA MUND</div>
    <div id="output" style="display:none">Only for test</div>
    <script type="text/javascript">
    !function (global) {

      function $(element) {
        if (typeof (element) === 'string') {
          element = document.getElementById(element);
        }
        return element;
      }

      function _keypressInput(event) {
        var keyChar = String.fromCharCode(event.keyCode);
        console.log('INPUT: ' + event.keyCode + '=' + keyChar);
        // el problema es esta linea de codigo
        // los demas browser devuelven un codigo 13 para \n
        // mientras que host driver devuelve 10
        if (event.keyCode === 13) {
          $('output').style.display = '';
          event.preventDefault();
        }
        event.stopPropagation();
        event.stopped = true;
      }

      function _keypressTextArea(event) {
        var keyChar = String.fromCharCode(event.keyCode);
        console.log('TEXTAREA: ' + event.keyCode + '=' + keyChar);

        event.stopPropagation();
        event.stopped = true;
      }

      function _keypressSelect(event) {
        var keyChar = String.fromCharCode(event.keyCode);
        console.log('SELECT: ' + event.keyCode + '=' + keyChar);

        event.stopPropagation();
        event.stopped = true;
      }

      function _keypressBody(event) {
        var keyChar = String.fromCharCode(event.keyCode);
        console.log('BODY: ' + event.keyCode + '=' + keyChar);

        event.stopPropagation();
        event.stopped = true;
      }

      $('text').addEventListener('keypress', _keypressInput);
      $('select').addEventListener('keypress', _keypressSelect);
      $('textarea').addEventListener('keypress', _keypressTextArea);
      document.body.addEventListener('keypress', _keypressBody);
    }(this);
    </script>
  </body>
</html>
```

**test.rb**

``` ruby
require 'selenium-webdriver'
driver = Selenium::WebDriver.for(:remote, :url => "http://localhost:8910")
driver = Selenium::WebDriver.for(:phantomjs)
#driver.manage.window.resize_to(1286, 682)
#driver = Selenium::WebDriver.for(:chrome)
#driver = Selenium::WebDriver.for(:ie)
#driver = Selenium::WebDriver.for(:ff)

driver.navigate.to "http://localhost:3000/"

text = driver.find_element(:id, 'text')
text.send_keys("this and test\n")

element = driver.find_element(:id, 'output')

display = element.style('display')

# assert
if display == 'block'
  puts "TEST SUCCESS.."
else
  puts "TEST FAILURE.."
end

# view select
select = driver.find_element(:id, 'select')
select.send_keys("b\n")

# view textarea

textarea = driver.find_element(:id, 'textarea')
textarea.send_keys("this an part\nthis an new line")

# div
div = driver.find_element(:tag_name, 'body')
div.send_keys("e\n")


driver.quit
```
