### PR TITLE
Issue #228: Allowed the setting of custom headers

### DIFF
--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
@@ -112,6 +112,13 @@ public class PhantomJSDriverService extends DriverService {
     public static final String PHANTOMJS_PAGE_SETTINGS_PREFIX = "phantomjs.page.settings.";
 
     /**
+     * Set capabilities with this prefix to apply it to the PhantomJS <code>page.customHeaders.*</code> object.
+     * Any header can be used.
+     * See <a href="https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-customHeaders">PhantomJS docs/a>.
+     */
+    public static final String PHANTOMJS_PAGE_CUSTOMHEADERS_PREFIX = "phantomjs.page.customHeaders.";
+
+    /**
      * Default Log file name.
      * Can be changed using {@link PhantomJSDriverService.Builder#withLogFile(java.io.File)}.
      */

--- a/src/session.js
+++ b/src/session.js
@@ -104,18 +104,28 @@ ghostdriver.Session = function(desiredCapabilities) {
     _id = require("./third_party/uuid.js").v1(),
     _inputs = ghostdriver.Inputs(),
     _capsPageSettingsPref = "phantomjs.page.settings.",
+    _capsPageCustomHeadersPref = "phantomjs.page.customHeaders.",
     _pageSettings = {},
+    _pageCustomHeaders = {},
     _log = ghostdriver.logger.create("Session [" + _id + "]"),
-    k, settingKey;
+    k, settingKey, headerKey;
 
-    // Searching for `phantomjs.settings.*` in the Desired Capabilities and merging with the Negotiated Capabilities
-    // Possible values: @see https://github.com/ariya/phantomjs/wiki/API-Reference#wiki-webpage-settings.
+    // Searching for `phantomjs.settings.* and phantomjs.customHeaders.*` in the Desired Capabilities and merging with the Negotiated Capabilities
+    // Possible values for settings: @see https://github.com/ariya/phantomjs/wiki/API-Reference#wiki-webpage-settings.
+    // Possible values for customHeaders: @see https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-customHeaders.
     for (k in desiredCapabilities) {
         if (k.indexOf(_capsPageSettingsPref) === 0) {
             settingKey = k.substring(_capsPageSettingsPref.length);
             if (settingKey.length > 0) {
                 _negotiatedCapabilities[k] = desiredCapabilities[k];
                 _pageSettings[settingKey] = desiredCapabilities[k];
+            }
+        }
+        if (k.indexOf(_capsPageCustomHeadersPref) === 0) {
+            headerKey = k.substring(_capsPageCustomHeadersPref.length);
+            if (headerKey.length > 0) {
+                _negotiatedCapabilities[k] = desiredCapabilities[k];
+                _pageCustomHeaders[headerKey] = desiredCapabilities[k];
             }
         }
     }
@@ -303,10 +313,13 @@ ghostdriver.Session = function(desiredCapabilities) {
                 page.settings[k] = _pageSettings[k];
             }
         }
+        // 7. Applying Page custom headers received via capabilities
+        page.customHeaders = _pageCustomHeaders;
 
         page.onConsoleMessage = function(msg) { _log.debug("page.onConsoleMessage", msg); };
 
-        _log.debug("_decorateNewWindow", "page.settings: " + JSON.stringify(page.settings));
+        _log.info("_decorateNewWindow", "page.settings: " + JSON.stringify(page.settings));
+        _log.info("page.customHeaders: ", JSON.stringify(page.customHeaders));
 
         return page;
     },


### PR DESCRIPTION
This pull-request allows you to pass custom request headers down to PhantomJS. The syntax for doing so is a little different to [the PhantomJS equivalent](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-customHeaders), but is relatively simple:

In PhantomJS, you might do something like:

``` javascript
var page = require('webpage').create();
page.customHeaders = {
  'Accept-Language': 'it-IT',
  'Max-Forwards': '6'
};
```

And (with this patch), you can do:

``` java
capabilities.setCapability(PHANTOMJS_PAGE_CUSTOMHEADERS_PREFIX + "Accept-Language", "it-IT");
capabilities.setCapability(PHANTOMJS_PAGE_CUSTOMHEADERS_PREFIX + "Max-Forwards", "6");
```

_Similar resolved issues:_ Issue #134 

**Technical notes:**
After the iterations on the implementation, we've ended up with a bit of duplication. My Javascript skills are sufficiently bad that I'm not going to refactor it without the tools to test afterward (latest commit is from a dying laptop with no charger), so I'll leave that in for now. To be fair, it reads fine anyway.

Also, it'd be nice to update the page.customHeaders object so that we don't lose any previous key/values that may have existed. Not _really_ a problem, as it doesn't look like we have any default headers at the moment anyway, but it might need to be changed in the future.
