### PR TITLE
Setting to 'String' type in initialisation of list.

### DIFF
--- a/test/java/src/test/java/ghostdriver/BaseTest.java
+++ b/test/java/src/test/java/ghostdriver/BaseTest.java
@@ -106,7 +106,7 @@ public abstract class BaseTest {
 //            "--ssl-protocol=any",
 //            "--ignore-ssl-errors=true"
 //        });
-        ArrayList<String> cliArgsCap = new ArrayList<>();
+        ArrayList<String> cliArgsCap = new ArrayList<String>();
         cliArgsCap.add("--web-security=false");
         cliArgsCap.add("--ssl-protocol=any");
         cliArgsCap.add("--ignore-ssl-errors=true");


### PR DESCRIPTION
Compilation error on BaseTest when running the Gradle tests due to empty type.
