### PR TITLE
click events can work off existing mouse locations - fix a bug when no post data is sent

### DIFF
--- a/src/request_handlers/session_request_handler.js
+++ b/src/request_handlers/session_request_handler.js
@@ -693,8 +693,8 @@ ghostdriver.SessionReqHand = function(session) {
         // normalize click
         clickType = clickType || "click";
 
-        // The protocol allows language bindings to send an empty string
-        if (req.post.length > 0) {
+        // The protocol allows language bindings to send an empty string (or no data at all)
+        if (req.post && req.post.length > 0) {
             postObj = JSON.parse(req.post);
         }
 


### PR DESCRIPTION
Both the Firefox and Chrome driver accept the /buttondown call with no post data. With Phantom I was getting this error message:

Phantom failed: [ERROR - 2013-08-29T18:21:21.612Z] RouterReqHand - _handle - Thrown => {
  "message": "'undefined' is not an object (evaluating 'req.post.length')",
  "line": 702,
  "sourceId": 146917728,
  "sourceURL": ":/ghostdriver/request_handlers/session_request_handler.js",
  "stack": "TypeError: 'undefined' is not an object (evaluating 'req.post.length')\n    at :/ghostdriver/request_handlers/session_request_handler.js:702\n    at :/ghostdriver/request_handlers/session_request_handler.js:164\n    at :/ghostdriver/request_handlers/request_handler.js:61\n    at :/ghostdriver/request_handlers/router_request_handler.js:82",
  "stackArray": [
    {
      "sourceURL": ":/ghostdriver/request_handlers/session_request_handler.js",
      "line": 702
    },
    {
      "sourceURL": ":/ghostdriver/request_handlers/session_request_handler.js",
      "line": 164
    },
    {
      "sourceURL": ":/ghostdriver/request_handlers/request_handler.js",
      "line": 61
    },
    {
      "sourceURL": ":/ghostdriver/request_handlers/router_request_handler.js",
      "line": 82
    }
  ]
}

*\* NOTE: I might be wrong, but it seems like the only post data that seems relevant to _postMouseClickCommand() is which mouse button to click, not the "Element ID or an X-Y Offset" as the comments in the code suggest.
