### PR TITLE
Added keepAlive option.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,8 @@ var defaultConfig = {
         "hub"       : null,
         "logFile"   : null,
         "logLevel"  : "INFO",
-        "logColor"  : false
+        "logColor"  : false,
+        "keepAlive" : false
     },
     config = {
         "ip"        : defaultConfig.ip,
@@ -40,7 +41,8 @@ var defaultConfig = {
         "hub"       : defaultConfig.hub,
         "logFile"   : defaultConfig.logFile,
         "logLevel"  : defaultConfig.logLevel,
-        "logColor"  : defaultConfig.logColor
+        "logColor"  : defaultConfig.logColor,
+        "keepAlive" : defaultConfig.keepAlive
     },
     logOutputFile = null,
     logger = require("./logger.js"),

--- a/src/main.js
+++ b/src/main.js
@@ -66,7 +66,7 @@ try {
     router = new ghostdriver.RouterReqHand();
 
     // Start the server
-    if (server.listen(ghostdriver.config.port, router.handle)) {
+    if (server.listen(ghostdriver.config.port, {"keepAlive": ghostdriver.config.keepAlive}, router.handle)) {
         _log.info("Main", "running on port " + server.port);
 
         // If a Selenium Grid HUB was provided, register to it!


### PR DESCRIPTION
There is an issue with the use of the latest version of Selenium with PhantomJS & GhostDriver in that Selenium was [recently changed to use keep-alive for remote connections](https://github.com/SeleniumHQ/selenium/commit/93dc1284534330866238d85521e40dd4de435def), now assuming that the WebDriver connection supports keep-alive and that it can leave the socket open. Unfortunately, by default, keep-alive is disabled in PhantomJS, [creating an issue](https://code.google.com/p/selenium/issues/detail?id=6690) when the two are used together in which GhostDriver closes the HTTP connection while Selenium has requested it remain open.

I've developed a fix in the form of adding a command line argument to PhantomJS that enables keep-alive in GhostDriver. This is the first part of that fix in the form of adding a `keepAlive` option to GhostDriver that can be called from PhantomJS based on the value of the command line argument.

I assume the protocol would be to get this merged to ghostdriver/master, wait for the changes to be added to the PhantomJS repo, and then submit a pull request on the PhantomJS repo for the changes involving the command line argument. Any clarification on the process would be appreciated :smile: 
