### PR TITLE
ArgumentsBuilder: make SOCKS proxy authorization optional, add null checks if proxy url is set

### DIFF
--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
@@ -462,14 +462,17 @@ public class PhantomJSDriverService extends DriverService {
                 if (proxy != null) {
                     switch (proxy.getProxyType()) {
                         case MANUAL:
-                            if (!proxy.getHttpProxy().isEmpty()) {          //< HTTP proxy
+                            if (proxy.getHttpProxy() != null && !proxy.getHttpProxy().isEmpty()) {          //< HTTP proxy
                                 argsBuilder.add("--proxy-type=http");
                                 argsBuilder.add(String.format("--proxy=%s", proxy.getHttpProxy()));
-                            } else if (!proxy.getSocksProxy().isEmpty()) {  //< SOCKS5 proxy
+                            } else if (proxy.getSocksProxy() != null && !proxy.getSocksProxy().isEmpty()) {  //< SOCKS5 proxy
                                 argsBuilder.add("--proxy-type=socks5");
                                 argsBuilder.add(String.format("--proxy=%s", proxy.getSocksProxy()));
-                                argsBuilder.add(String.format("--proxy-auth=%s:%s", proxy.getSocksUsername(),
-                                        proxy.getSocksPassword()));
+                                if (proxy.getSocksUsername() != null && !proxy.getSocksUsername().isEmpty()
+                                        && proxy.getSocksPassword() != null && !proxy.getSocksPassword().isEmpty()) {
+	                                argsBuilder.add(String.format("--proxy-auth=%s:%s", proxy.getSocksUsername(),
+	                                        proxy.getSocksPassword()));
+                                }
                             } else {
                                 // TODO Not supported yet by PhantomJS
                                 checkArgument(true, "PhantomJS supports only HTTP and Socks5 Proxy currently");


### PR DESCRIPTION
Suppose developer wants to use the SOCKS proxy

``` Shell
ssh -D 1080 user@host
```

Examine the following code:

``` Java
final DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
final Proxy proxy = new Proxy();
proxy.setHttpProxy(""); // Workaround: httpProxy defaults to null -> NullPointerException @ PhantomJSDriverService:465 [if (!proxy.getHttpProxy().isEmpty()) {          //< HTTP proxy]
proxy.setSocksProxy("127.0.0.1:8000");
capabilities.setCapability(CapabilityType.PROXY, proxy);
final WebDriver webDriver = new PhantomJSDriver(capabilities);
```

httpProxy must be set to empty string
also there is no way to not use the SOCKS authorization
current implementation appends invalid

``` Shell
--proxy-auth=null:null
```
