### PR TITLE
Fixed HTTP  authentication.

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -332,9 +332,11 @@ ghostdriver.Session = function(desiredCapabilities) {
         page.onClosing = _deleteClosingPage;
 
         // 6. Applying Page settings received via capabilities
+        // by default this property is not present in settings
+        var httpAuth = ['userName', 'password'];
         for (k in _pageSettings) {
             // Apply setting only if really supported by PhantomJS
-            if (page.settings.hasOwnProperty(k)) {
+            if (page.settings.hasOwnProperty(k) || httpAuth.indexOf(k) !== -1) {
                 page.settings[k] = _pageSettings[k];
             }
         }


### PR DESCRIPTION
Currently this does not work, by userName and password property is not present in page settings

https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-settings

userName sets the user name used for HTTP authentication.
password sets the password used for HTTP authentication.
