### PR TITLE
fix for HTTP Authentication

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -106,6 +106,7 @@ ghostdriver.Session = function(desiredCapabilities) {
     _capsPageSettingsPref = "phantomjs.page.settings.",
     _capsPageCustomHeadersPref = "phantomjs.page.customHeaders.",
     _pageSettings = {},
+    _additionalAllowedPageSettings = { userName: 1, password: 1 },
     _pageCustomHeaders = {},
     _log = ghostdriver.logger.create("Session [" + _id + "]"),
     k, settingKey, headerKey;
@@ -329,7 +330,7 @@ ghostdriver.Session = function(desiredCapabilities) {
         // 6. Applying Page settings received via capabilities
         for (k in _pageSettings) {
             // Apply setting only if really supported by PhantomJS
-            if (page.settings.hasOwnProperty(k)) {
+            if (page.settings.hasOwnProperty(k) || _additionalAllowedPageSettings.hasOwnProperty(k)) {
                 page.settings[k] = _pageSettings[k];
             }
         }

--- a/test/java/src/test/java/ghostdriver/AuthBasicTest.java
+++ b/test/java/src/test/java/ghostdriver/AuthBasicTest.java
@@ -1,0 +1,37 @@
+package ghostdriver;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+
+public class AuthBasicTest extends BaseTest {
+
+    // credentials for testing, no one would ever use these
+    private final static String userName = "admin";
+    private final static String password = "admin";
+
+    @Override
+    public void prepareDriver() throws Exception {
+        sCaps.setCapability(PhantomJSDriverService.PHANTOMJS_PAGE_SETTINGS_PREFIX + "userName", userName);
+        sCaps.setCapability(PhantomJSDriverService.PHANTOMJS_PAGE_SETTINGS_PREFIX + "password", password);
+
+        super.prepareDriver();
+    }
+
+    @Test
+    public void simpleBasicAuthShouldWork() {
+        // Get Driver Instance
+        WebDriver driver = getDriver();
+
+        // wrong password
+        driver.get(String.format("http://httpbin.org/basic-auth/%s/Wrong%s", userName, password));
+        assertTrue(!driver.getPageSource().contains("authenticated"));
+
+        // we should be authorized
+        driver.get(String.format("http://httpbin.org/basic-auth/%s/%s", userName, password));
+        assertTrue(driver.getPageSource().contains("authenticated"));
+    }
+
+}


### PR DESCRIPTION
HTTP basic Authentication does not work, though user credentials are present in the negotiated Capabilities. The reason is, all keys, that do not exist in page.settings are filtered and ignored.

This commit fixes this by introducing an object holding additional settings to be allowed. It is built against tag 1.1.0, so it should be both easily backported or merged with master. 

Passing Tests are provided as well. Also, httpbin.org is fantastic for testing HTTP Requests.
