### PR TITLE
Introduced acceptSslCerts capability

### DIFF
--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/MultiSessionCommandExecutor.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/MultiSessionCommandExecutor.java
@@ -31,7 +31,7 @@ import org.openqa.selenium.remote.HttpCommandExecutor;
 
 /**
  * A specialized {@link org.openqa.selenium.remote.HttpCommandExecutor} that will use a
- * {@link PhantomJSDriverService}. Unlike {@Link PhantomJSCommandExecutor} the lifecycle
+ * {@link PhantomJSDriverService}. Unlike {@link PhantomJSCommandExecutor} the lifecycle
  * of the service is to be managed by the caller, allowing the use of one single service
  * by multiple drivers.
  */

--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriver.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriver.java
@@ -50,37 +50,37 @@ import static org.openqa.selenium.remote.http.HttpMethod.POST;
  * A {@link org.openqa.selenium.WebDriver} implementation that controls a PhantomJS running in Remote WebDriver mode.
  * This class is provided as a convenience for easily testing PhantomJS.
  * The control server which each instance communicates with will live and die with the instance.
- * <p/>
+ *
  * The Driver requires to optionally set some Capabilities or Environment Variables:
  * <ul>
  * <li>{@link PhantomJSDriverService#PHANTOMJS_EXECUTABLE_PATH_PROPERTY}</li>
  * <li>{@link PhantomJSDriverService#PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY}</li>
  * </ul>
- * <p/>
+ *
  * {@link PhantomJSDriverService#PHANTOMJS_EXECUTABLE_PATH_PROPERTY} is required only if the executable
  * {@code phantomjs} is not available through the {@code $PATH} environment variable:
  * you can provide it either via the {@link Capabilities} construction parameter object,
  * or via {@link System} Property.
- * <p/>
+ *
  * {@link PhantomJSDriverService#PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY} is optional in case you want to use a specific
  * version of GhostDriver (i.e. during development of GhostDriver).
  * You can provide it either via the {@link Capabilities} construction parameter object,
  * or via {@link System} Property.
- * <p/>
+ *
  * Instead, if you have a PhantomJS WebDriver process already running, you can instead use {@link
  * RemoteWebDriver#RemoteWebDriver(java.net.URL, org.openqa.selenium.Capabilities)} to delegate the
  * execution of your WebDriver/Selenium scripts to it. Of course, in that case you will than be in
  * charge to control the life-cycle of the PhantomJS process.
- * <p/>
+ *
  * NOTE: PhantomJS Remote WebDriver mode is implemented via
  * <a href="https://github.com/detro/ghostdriver">GhostDriver</a>.
  * It's a separate project that, at every stable release, is merged into PhantomJS.
  * If interested in developing (contributing to) GhostDriver, it's possible to run PhantomJS and pass GhostDriver as
  * a script.
- * <p/>
+ *
  * NOTE: The design of this class is heavily inspired by {@link org.openqa.selenium.chrome.ChromeDriver}.
  *
- * @author Ivan De Marino <http://ivandemarino.me>
+ * @author Ivan De Marino http://ivandemarino.me
  * @see PhantomJSDriverService#createDefaultService()
  */
 public class PhantomJSDriver extends RemoteWebDriver implements TakesScreenshot {
@@ -142,16 +142,16 @@ public class PhantomJSDriver extends RemoteWebDriver implements TakesScreenshot 
     /**
      * Execute a PhantomJS fragment.  Provides extra functionality not found in WebDriver
      * but available in PhantomJS.
-     * <p/>
-     * See the <a href="http://phantomjs.org/api/">PhantomJS API<</a>
+     * 
+     * See the <a href="http://phantomjs.org/api/">PhantomJS API</a>
      * for details on what is available.
-     * <p/>
+     *</p>
      * A 'page' variable pointing to currently selected page is available for use.
      * If there is no page yet, one is created.
-     * <p/>
+     *
      * When overriding any callbacks be sure to wrap in a try/catch block, as failures
      * may cause future WebDriver calls to fail.
-     * <p/>
+     *
      * Certain callbacks are used by GhostDriver (the PhantomJS WebDriver implementation)
      * already.  Overriding these may cause the script to fail.  It's a good idea to check
      * for existing callbacks before overriding.

--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
@@ -47,10 +47,10 @@ import static com.google.common.base.Preconditions.*;
 /**
  * Service that controls the life-cycle of a PhantomJS in Remote WebDriver mode.
  * The Remote WebDriver is implemented via GhostDriver.
- * <p/>
+ *
  * NOTE: Yes, the design of this class is heavily inspired by {@link org.openqa.selenium.chrome.ChromeDriverService}.
  *
- * @author Ivan De Marino <http://ivandemarino.me>
+ * @author Ivan De Marino http://ivandemarino.me
  */
 public class PhantomJSDriverService extends DriverService {
 
@@ -90,33 +90,40 @@ public class PhantomJSDriverService extends DriverService {
      * {@code new String[] { "--logFile=PATH", "--logLevel=DEBUG" }}.
      * </p>
      *
-     * <p>
+     *
      * Acceptable arguments:
-     * <ul>
-     *     <li>{@code --ip=IP_GHOSTDRIVER_SHOULD_LISTEN_ON}</li>
-     *     <li>{@code --port=PORT_GHOSTDRIVER_SHOULD_LISTEN_ON}</li>
-     *     <li>{@code --hub=HTTP_ADDRESS_TO_SELENIUM_HUB}</li>
-     *     <li>{@code --logFile=PATH_TO_LOGFILE}</li>
-     *     <li>{@code --logLevel=(INFO|DEBUG|WARN|ERROR)}</li>
-     *     <li>{@code --logColor=(false|true)}</li>
-     * </ul>
-     * </p>
+     *  <ul>
+     *      <li><code>--ip=IP_GHOSTDRIVER_SHOULD_LISTEN_ON</code></li>
+     *      <li><code>--port=PORT_GHOSTDRIVER_SHOULD_LISTEN_ON</code></li>
+     *      <li><code>--hub=HTTP_ADDRESS_TO_SELENIUM_HUB</code></li>
+     *      <li><code>--logFile=PATH_TO_LOGFILE</code></li>
+     *      <li><code>--logLevel=(INFO|DEBUG|WARN|ERROR)</code></li>
+     *      <li><code>--logColor=(false|true)</code></li>
+     *  </ul>
+     *
      */
     public static final String PHANTOMJS_GHOSTDRIVER_CLI_ARGS = "phantomjs.ghostdriver.cli.args";
 
     /**
      * Set capabilities with this prefix to apply it to the PhantomJS {@code page.settings.*} object.
      * Every PhantomJS WebPage Setting can be used.
-     * See <a href="http://phantomjs.org/api/webpage/property/settings.html">PhantomJS docs/a>.
+     * See <a href="http://phantomjs.org/api/webpage/property/settings.html">PhantomJS docs</a>.
      */
     public static final String PHANTOMJS_PAGE_SETTINGS_PREFIX = "phantomjs.page.settings.";
 
     /**
      * Set capabilities with this prefix to apply it to the PhantomJS {@code page.customHeaders.*} object.
      * Any header can be used.
-     * See <a href="http://phantomjs.org/api/webpage/property/custom-headers.html">PhantomJS docs/a>.
+     * See <a href="http://phantomjs.org/api/webpage/property/custom-headers.html">PhantomJS docs</a>.
      */
     public static final String PHANTOMJS_PAGE_CUSTOMHEADERS_PREFIX = "phantomjs.page.customHeaders.";
+
+    /**
+     * Capability that allows to access to those sites using self-signed or invalid certificates, and where the certificate
+     * does not match the serving domain as if the HTTPS was configured properly.
+     */
+    public static final String ACCEPT_SSL_CERTS = "acceptSslCerts";
+
 
     /**
      * Default Log file name.
@@ -155,7 +162,7 @@ public class PhantomJSDriverService extends DriverService {
 
     /**
      * Configures and returns a new {@link PhantomJSDriverService} using the default configuration.
-     * <p/>
+     *
      * In this configuration, the service will use the PhantomJS executable identified by the the
      * following capability, system property or PATH environment variables:
      * <ul>
@@ -165,7 +172,7 @@ public class PhantomJSDriverService extends DriverService {
      *          (Optional - without will use GhostDriver internal to PhantomJS)
      *      </li>
      * </ul>
-     * <p/>
+     *
      * Each service created by this method will be configured to find and use a free port on the current system.
      *
      * @return A new ChromeDriverService using the default configuration.
@@ -189,6 +196,7 @@ public class PhantomJSDriverService extends DriverService {
                 .usingAnyFreePort()
                 .withProxy(proxy)
                 .withLogFile(new File(PHANTOMJS_DEFAULT_LOGFILE))
+                .withAcceptSslCerts(findAcceptSslCerts(desiredCapabilities))
                 .usingCommandLineArguments(
                         findCLIArgumentsFromCaps(desiredCapabilities, PHANTOMJS_CLI_ARGS))
                 .usingGhostDriverCommandLineArguments(
@@ -198,7 +206,7 @@ public class PhantomJSDriverService extends DriverService {
 
     /**
      * Same as {@link PhantomJSDriverService#createDefaultService(org.openqa.selenium.Capabilities)}.
-     * <p/>
+     *
      * In this case PhantomJS or GhostDriver can't be searched within the Capabilities, only System
      * Properties.
      *
@@ -211,7 +219,7 @@ public class PhantomJSDriverService extends DriverService {
     /**
      * Looks into the Capabilities, the current $PATH and the System Properties for
      * {@link PhantomJSDriverService#PHANTOMJS_EXECUTABLE_PATH_PROPERTY}.
-     * <p/>
+     *
      * NOTE: If the Capability, the $PATH and the System Property are set, the Capability takes
      * priority over the System Property, that in turn takes priority over the $PATH.
      *
@@ -246,12 +254,20 @@ public class PhantomJSDriverService extends DriverService {
         return phantomjs;
     }
 
+    protected static boolean findAcceptSslCerts(Capabilities desiredCapabilities) {
+        if (desiredCapabilities != null &&
+                desiredCapabilities.getCapability(ACCEPT_SSL_CERTS) != null) {
+            return (Boolean) desiredCapabilities.getCapability(ACCEPT_SSL_CERTS);
+        }
+        return false;
+    }
+
     /**
      * Find the GhostDriver main file (i.e. {@code "main.js"}).
-     * <p/>
+     *
      * Looks into the Capabilities and the System Properties for
      * {@link PhantomJSDriverService#PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY}.
-     * <p/>
+     *
      * NOTE: If both the Capability and the System Property are set, the Capability takes priority.
      *
      * @param desiredCapabilities Capabilities in which we will look for the path to GhostDriver
@@ -326,6 +342,7 @@ public class PhantomJSDriverService extends DriverService {
         private Proxy proxy = null;
         private String[] commandLineArguments = null;
         private String[] ghostdriverCommandLineArguments = null;
+        private boolean acceptSslCerts = false;
 
         /**
          * Sets which PhantomJS executable the builder will use.
@@ -399,7 +416,7 @@ public class PhantomJSDriverService extends DriverService {
 
         /**
          * Configures the service to use a specific Proxy configuration.
-         * <p/>
+         *
          * NOTE: Usually the proxy configuration is passed to the Remote WebDriver via WireProtocol
          * Capabilities. PhantomJS doesn't yet support protocol configuration at runtime: it
          * requires it to be defined on launch.
@@ -487,6 +504,12 @@ public class PhantomJSDriverService extends DriverService {
                     }
                 }
 
+                if (this.acceptSslCerts) {
+                    argsBuilder.add("--web-security=false");
+                    argsBuilder.add("--ssl-protocol=any");
+                    argsBuilder.add("--ignore-ssl-errors=true");
+                }
+
                 // Additional command line arguments (if provided)
                 if (this.commandLineArguments != null) {
                     argsBuilder.add(this.commandLineArguments);
@@ -530,6 +553,10 @@ public class PhantomJSDriverService extends DriverService {
                 throw new WebDriverException(e);
             }
         }
+        public Builder withAcceptSslCerts(boolean acceptSslCerts) {
+            this.acceptSslCerts = acceptSslCerts;
+            return this;
+        }
 
         private boolean argsContains(String[] args, String targetArg) {
             if (args != null) {
@@ -542,6 +569,5 @@ public class PhantomJSDriverService extends DriverService {
             }
 
             return false;
-        }
     }
 }


### PR DESCRIPTION
This commit should fix #233, Let me know what do you think.

Capability that allows to access to those sites using self-signed or invalid
certificates, and where the certificate does not match the serving domain as
if the HTTPS was configured properly.
settings
'--web-security=false'
'--ssl-protocol=any'
'--ignore-ssl-errors=true'

Fixed some html tags in the javadoc