### PR TITLE
Whitelist page.settings.resourceTimeout

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -113,6 +113,7 @@ ghostdriver.Session = function(desiredCapabilities) {
     _capsPageSettingsProxyPref = "proxy",
     _pageSettings = {},
     _additionalPageSettings = {
+        resourceTimeout: null,
         userName: null,
         password: null
     },


### PR DESCRIPTION
Tested by making the same change in phantomjs' ghostdriver copy.

Fixes https://github.com/detro/ghostdriver/issues/380
