### PR TITLE
Code cleanup

### DIFF
--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
@@ -225,7 +225,7 @@ public class PhantomJSDriverService extends DriverService {
     @SuppressWarnings("deprecation")
     protected static File findPhantomJS(Capabilities desiredCapabilities, String docsLink,
                                         String downloadLink) {
-        String phantomjspath = null;
+        String phantomjspath;
         if (desiredCapabilities != null &&
                 desiredCapabilities.getCapability(PHANTOMJS_EXECUTABLE_PATH_PROPERTY) != null) {
             phantomjspath = (String) desiredCapabilities.getCapability(PHANTOMJS_EXECUTABLE_PATH_PROPERTY);
@@ -263,23 +263,15 @@ public class PhantomJSDriverService extends DriverService {
      */
     protected static File findGhostDriver(Capabilities desiredCapabilities, String docsLink, String downloadLink) {
         // Recover path to GhostDriver from the System Properties or the Capabilities
-        String ghostdriverpath = null;
+        String ghostdriverpath;
         if (desiredCapabilities != null &&
-                (String) desiredCapabilities.getCapability(PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY) != null) {
+                desiredCapabilities.getCapability(PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY) != null) {
             ghostdriverpath = (String) desiredCapabilities.getCapability(PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY);
         } else {
-            ghostdriverpath = System.getProperty(PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY, ghostdriverpath);
+            ghostdriverpath = System.getProperty(PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY);
         }
 
         if (ghostdriverpath != null) {
-            checkState(ghostdriverpath != null,
-                    "The path to the driver executable must be set by the '%s' capability/system property;"
-                            + " for more information, see %s. "
-                            + "The latest version can be downloaded from %s",
-                    PHANTOMJS_GHOSTDRIVER_PATH_PROPERTY,
-                    docsLink,
-                    downloadLink);
-
             // Check few things on the file before returning it
             File ghostdriver = new File(ghostdriverpath);
             checkState(ghostdriver.exists(),


### PR DESCRIPTION
- Remove unused assignment to null;
- Remove useless casting to String
- Remove useless checkState because ghostdriverpath is never null at this point