### PR TITLE
Add the ability to share the same phantomjs process with multiple Phanto...

### DIFF
--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/MultiSessionCommandExecutor.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/MultiSessionCommandExecutor.java
@@ -1,0 +1,49 @@
+/*
+This file is part of the GhostDriver by Ivan De Marino <http://ivandemarino.me>.
+
+Copyright (c) 2012-2014, Ivan De Marino <http://ivandemarino.me>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package org.openqa.selenium.phantomjs;
+
+import org.openqa.selenium.remote.HttpCommandExecutor;
+
+/**
+ * A specialized {@link org.openqa.selenium.remote.HttpCommandExecutor} that will use a
+ * {@link PhantomJSDriverService}. Unlike {@Link PhantomJSCommandExecutor} the lifecycle
+ * of the service is to be managed by the caller, allowing the use of one single service
+ * by multiple drivers.
+ */
+public class MultiSessionCommandExecutor extends HttpCommandExecutor {
+
+    /**
+     * Creates a new MultiSessionCommandExecutor.
+     * The PhantomJSCommandExecutor will communicate with the PhantomJS/GhostDriver through the given {@code service}.
+     *
+     * @param service The PhantomJSDriverService to send commands to.
+     */
+    public MultiSessionCommandExecutor(PhantomJSDriverService service) {
+        super(PhantomJSDriver.getCustomCommands(), service.getUrl());
+    }
+}

--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriver.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriver.java
@@ -30,6 +30,7 @@ package org.openqa.selenium.phantomjs;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -37,6 +38,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.DriverCommand;
+import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.internal.WebElementToJsonConverter;
 
@@ -113,6 +115,16 @@ public class PhantomJSDriver extends RemoteWebDriver implements TakesScreenshot 
      */
     public PhantomJSDriver(PhantomJSDriverService service, Capabilities desiredCapabilities) {
         super(new PhantomJSCommandExecutor(service), desiredCapabilities);
+    }
+
+    /**
+     * Creates a new PhantomJSDriver instance using the given HttpCommandExecutor.
+     *
+     * @param service             The command executor to use
+     * @param desiredCapabilities The capabilities required from PhantomJS/GhostDriver.
+     */
+    public PhantomJSDriver(HttpCommandExecutor executor, Capabilities desiredCapabilities) {
+        super(executor, desiredCapabilities);
     }
 
     /**


### PR DESCRIPTION
...mJSDriver

Currently we can't use the same phantomjs process with multiple PhantomJSDriver. Either
we use the RemoteDriver class directly but then we lose the ability to execute PhantomJS
scripts, or we use the PhantomJSDriver and we get a process per driver.

This commit adds a different HttpCommandExecutor subclass which defers the management
of the lifecyle of the PhantomJSService to a higher level, allowing to share the
same service by multiple drivers.