### PR TITLE
Reset log buffer after each POST request to /session/:sessionId/logs

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -680,6 +680,7 @@ ghostdriver.Session = function(desiredCapabilities) {
             tmp.push(_createLogEntry(
                 "INFO",
                 JSON.stringify(har.createHar(page, page.resources))));
+            page.resources = [];
             return tmp;
         }
 

--- a/src/session.js
+++ b/src/session.js
@@ -685,7 +685,10 @@ ghostdriver.Session = function(desiredCapabilities) {
 
         // Return Browser Console Log
         if (type === _const.LOG_TYPES.BROWSER) {
-            return _getCurrentWindow().browserLog;
+            page = _getCurrentWindow();
+            tmp = page.browserLog;
+            page.browserLog = [];
+            return tmp;
         }
 
         // Return empty Log

--- a/test/java/src/test/java/ghostdriver/LogTest.java
+++ b/test/java/src/test/java/ghostdriver/LogTest.java
@@ -75,6 +75,10 @@ public class LogTest extends BaseTestWithServer {
         for (LogEntry logEntry : logEntries) {
             System.out.println(logEntry);
         }
+
+        // Clears logs
+        logEntries = d.manage().logs().get("browser");
+        assertEquals(0, logEntries.getAll().size());
     }
 
     @Test

--- a/test/java/src/test/java/ghostdriver/LogTest.java
+++ b/test/java/src/test/java/ghostdriver/LogTest.java
@@ -90,5 +90,9 @@ public class LogTest extends BaseTestWithServer {
         for (LogEntry logEntry : logEntries) {
             System.out.println(logEntry);
         }
+
+        String firstRequestMessage = logEntries.getAll().get(0).getMessage();
+        String secondRequestMessage = d.manage().logs().get("har").getAll().get(0).getMessage();
+        assertTrue(secondRequestMessage.length() < firstRequestMessage.length());
     }
 }


### PR DESCRIPTION
According the [WebDriver Wire Protocol](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/log), log buffers should be cleared after each successful request.

It's less clear what this means for the single HAR log that is returned for the `har` log type. I cleared `page.resources`, which is what happens when the page is refreshed.

Let me know what you think! This is causing issues for [Agouti](http://github.com/sclevine/agouti).

-Stephen