### PR TITLE
Resolve issue #394 by fixing platform capability reference

### DIFF
--- a/src/hub_register.js
+++ b/src/hub_register.js
@@ -32,14 +32,23 @@ var nodeconf = function(ip, port, hub, proxy, version) {
         ref$ = hub.match(/([\w\d\.]+):(\d+)/);
         hubHost = ref$[1];
         hubPort = +ref$[2]; //< ensure it's of type "number"
+        var platform;
+        if(ghostdriver && ghostdriver.system){
+            platform = ghostdriver.system.os.name.toUpperCase();
+        }
+        else{
+            // The prior behavior was to just assume Linux.
+            // Worst case scenario, we get the status quo, but
+            // this block is really just a guard condition anyway
+            platform = "LINUX";
+        }
 
-        var ghostdriver = ghostdriver || {};
 
         return {
             capabilities: [{
                 browserName: "phantomjs",
                 version: version,
-                platform: ghostdriver.system.os.name + '-' + ghostdriver.system.os.version + '-' + ghostdriver.system.os.architecture,
+                platform: platform,
                 maxInstances: 1,
                 seleniumProtocol: "WebDriver"
             }],


### PR DESCRIPTION
The previous code prevented PhantomJS from registering with a Selenium Grid Hub(Issue #394 ). Thanks to @darwin10's workaround, I noticed two things:

- The `ghostdriver` variable was reinitialized to an empty object and therefore threw undefined errors
- The code generated a platform identifier that was being rejected by the grid server. (LINUX, MAC, and WINDOWS are valid platforms) 