### PR TITLE
Change the regular expression for the CLI arguments.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -78,7 +78,7 @@ function apply () {
 
 exports.init = function(cliArgs) {
     var i, k,
-        regexp = new RegExp("^--([a-z]+)=([a-z0-9_/\\\\:.]+)$", "i"),
+        regexp = new RegExp("^--([a-z]+)=([^\x00-\x1f\x7f\u2028\u2029]+)$", "i"),
         regexpRes;
 
     // Loop over all the Command Line Arguments


### PR DESCRIPTION
Original expression doesn't allow to space and non-ascii characters in the log file path.

For example, the following code doesn't create any log file.
		PhantomJSDriverService service =
				builder.usingGhostDriverCommandLineArguments(new String[] { "--logFile=c:\\temp\\space in path\\log.txt" })
				.build();
