### PR TITLE
add error handling to send keys

### DIFF
--- a/src/request_handlers/webelement_request_handler.js
+++ b/src/request_handlers/webelement_request_handler.js
@@ -275,7 +275,7 @@ ghostdriver.WebElementReqHand = function(idOrElement, session) {
                     for (var i = 0; i < multiFileText.length; ++i) {
                         if (!fsModule.exists(multiFileText[i])) {
                             _log.debug("File does not exist: " + multiFileText[i]);
-                            res.respondBasedOnResult(_session, req, JSON.stringify({status: 0, value: null}));
+                            res.success(_session.getId());
                             return;
                         }
                     }
@@ -293,7 +293,7 @@ ghostdriver.WebElementReqHand = function(idOrElement, session) {
                 // abort if file does not exist
                 if (!fsModule.exists(text)) {
                     _log.debug("File does not exist: " + text);
-                    res.respondBasedOnResult(_session, req, JSON.stringify({status: 0, value: null}));
+                     res.success(_session.getId());
                     return;
                 }
 

--- a/test/fixtures/common/formPage.html
+++ b/test/fixtures/common/formPage.html
@@ -127,6 +127,8 @@ There should be a form here:
 
     <input id="no-type" />
     <input type="file" id="upload" onchange="document.getElementById('fileResults').innerHTML = 'changed';" />
+    <input type="file" id="multiple_upload" onchange="document.getElementById('fileResults').innerHTML = 'changed';"
+		multiple/>
     <span id="fileResults"></span>
 
     <input type="submit" />

--- a/test/fixtures/common/send_keys_visibility.html
+++ b/test/fixtures/common/send_keys_visibility.html
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>An element that disappears on click</title>
+  <style>
+#log {
+  position: absolute;
+  top: 120px;
+}
+  </style>
+</head>
+<body id="body">
+  <div style="visibility: hidden;">
+    <span>
+      <input id="unclickable" />
+      <input type="file" id="unclickable_file" />
+    </span>
+  </div>
+  <div id="log">
+    <p>Log:<p>
+  </div>
+<script>
+var byId = document.getElementById.bind(document);
+
+var log = byId("log");
+
+function handler(ev) {
+  log.innerHTML += "<p></p>";
+  log.lastElementChild.textContent = ev.type + " in " + ev.target.id + " (handled by " + ev.currentTarget.id + ")\n";
+}
+
+var body = document.body;
+
+var types = ["keypress", "keydown", "keyup"];
+for (var i = 0, type; (type = types[i]); ++i) {
+  body.addEventListener(type, handler);
+}
+</script>
+</body>
+</html>

--- a/test/fixtures/common/upload-multiple.html
+++ b/test/fixtures/common/upload-multiple.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<title>Upload Form</title>
+<script>
+  var intervalId;
+  function onTick() {
+    var label = document.getElementById('upload_label');
+    label.innerHTML += '.';
+  }
+
+  function onUploadSubmit() {
+    document.getElementById('upload_target').contentWindow.document.body.
+        innerHTML = '';
+    var label = document.getElementById('upload_label');
+    label.innerHTML = 'Uploading "' + document.forms[0].upload.value + '"';
+    label.style.display = '';
+    intervalId = window.setInterval(onTick, 500);
+    return true;
+  }
+
+  function onUploadDone() {
+    var label = document.getElementById('upload_label');
+    label.style.display = 'none';
+    window.clearInterval(intervalId);
+    return true;
+  }
+</script>
+<form action="/common/uploadmult" method="post" name="upload_form"
+      target="upload_target" enctype="multipart/form-data"
+      onsubmit="onUploadSubmit();">
+  <div>
+    Enter a file to upload:
+    <div><input id="upload" name="upload" type="file" multiple/></div>
+    <div><input id="go" type="submit" value="Go!"/></div>
+  </div>
+  <div id="upload_label" style="display:none"></div>
+  <iframe src="" id="upload_target" name="upload_target"
+          style="width:300px;height:200px">
+  </iframe>
+</form>

--- a/test/java/src/test/java/ghostdriver/FileUploadTest.java
+++ b/test/java/src/test/java/ghostdriver/FileUploadTest.java
@@ -39,6 +39,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.WebDriverException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -46,6 +47,7 @@ import java.io.*;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class FileUploadTest extends BaseTestWithServer {
@@ -167,5 +169,28 @@ public class FileUploadTest extends BaseTestWithServer {
         d.findElement(By.id("id-name1")).click();
 
         assertEquals("changed", result.getText());
+     }
+
+    @Test
+    public void checkThrowUnsupportedErrorOnMultipleFileUpload() throws IOException {
+        WebDriver d = getDriver();
+
+        d.get(server.getBaseUrl() + "/common/formPage.html");
+        WebElement uploadElement = d.findElement(By.id("multiple_upload"));
+        WebElement result = d.findElement(By.id("fileResults"));
+        assertEquals("", result.getText());
+
+        File file = File.createTempFile("test", "txt");
+        file.deleteOnExit();
+
+        try {
+            uploadElement.sendKeys(file.getAbsolutePath());
+            fail("sending keys to a multiple-file upload should fail");
+        } catch (WebDriverException e) {
+        }
+        // Shift focus to something else because send key doesn't make the focus leave
+        d.findElement(By.id("id-name1")).click();
+
+        assertNotEquals("changed", result.getText());
      }
 }

--- a/test/java/src/test/java/ghostdriver/VisibilityTest.java
+++ b/test/java/src/test/java/ghostdriver/VisibilityTest.java
@@ -1,0 +1,95 @@
+/*
+This file is part of the GhostDriver by Ivan De Marino <http://ivandemarino.me>.
+
+Copyright (c) 2012-2014, Ivan De Marino <http://ivandemarino.me>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package ghostdriver;
+
+import ghostdriver.server.HttpRequestCallback;
+import org.junit.Test;
+import org.openqa.selenium.*;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import java.io.*;
+// import org.apache.commons.fileupload.FileItem;
+// import org.apache.commons.fileupload.FileUploadException;
+// import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+// import org.apache.commons.io.IOUtils;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class VisibilityTest extends BaseTestWithServer {
+
+    @Test
+    public void testShouldNotBeAbleToTypeToAnElementThatIsNotDisplayed() {
+
+        WebDriver d = getDriver();
+        d.get(server.getBaseUrl() + "/common/send_keys_visibility.html");
+
+        WebElement elem = d.findElement(By.id("unclickable"));
+
+        try {
+            elem.sendKeys("this is not visible");
+            fail("You should not be able to send keyboard input to an invisible element");
+        } catch (InvalidElementStateException e) {
+        }
+
+        assertFalse(elem.getAttribute("value").equals("this is not visible"));
+        assertTrue(d.findElement(By.id("log")).getText().trim().equals("Log:"));
+    }
+
+    @Test
+    public void testShouldNotBeAbleToTypeToAFileInputElementThatIsNotDisplayed() throws IOException {
+
+        // Create the test file for uploading
+        File testFile = File.createTempFile("webdriver", "tmp");
+        testFile.deleteOnExit();
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
+            new FileOutputStream(testFile.getAbsolutePath()), "utf-8"));
+        writer.write("Hello");
+        writer.close();
+
+        WebDriver d = getDriver();
+        d.get(server.getBaseUrl() + "/common/send_keys_visibility.html");
+
+        WebElement elem = d.findElement(By.id("unclickable_file"));
+
+        try {
+            elem.sendKeys(testFile.getAbsolutePath());
+            fail("You should not be able to send keyboard input to an invisible element");
+        } catch (ElementNotVisibleException e) {
+        }
+
+        assertFalse(elem.getAttribute("value").equals(testFile.getAbsolutePath()));
+        assertTrue(d.findElement(By.id("log")).getText().trim().equals("Log:"));
+    }
+}


### PR DESCRIPTION
this should remove some edge cases where ghostdriver will freeze.  specificity when the file element is not visible or when the file element has the multiple attribute.  hopefully this will help users debugging #282 .

edge cases covered:
* log error if file does not exist
* throw error on multiple file upload
* throw error if clicking on file for file upload fails
* throw error if focusing on the generic input element fails