### PR TITLE
update java client selenium dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ IRC channel: [#phantomjs-ghostdriver](http://webchat.freenode.net/?channels=%23p
 ## Setup
 
 * Download latest stable PhantomJS from [here](http://phantomjs.org/download.html)
-* Selenium version `">= 3.0.0`"
+* Selenium version `">= 3.1.0`"
 
 **THAT'S IT!!** Because of latest stable GhostDriver being embedded in PhantomJS,
 you shouldn't need anything else to get started.
@@ -62,7 +62,7 @@ For versions >= 2.0.0, add the following to your `pom.xml`:
 <dependency>
     <groupId>com.github.detro</groupId>
     <artifactId>ghostdriver</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 
@@ -81,7 +81,7 @@ allprojects {
 ```gradle
 dependencies {
     ...
-    testCompile 'com.github.detro:ghostdriver:2.0.0'
+    testCompile 'com.github.detro:ghostdriver:2.1.0'
     ...
 }
 ```

--- a/binding/java/build.gradle
+++ b/binding/java/build.gradle
@@ -48,9 +48,9 @@ compileJava {
     options.compilerArgs.add("-Xlint:deprecation")
 }
 
-ext.seleniumVersion         = "3.0.0"
+ext.seleniumVersion         = "3.1.0"
 project.archivesBaseName    = project.name
-project.version             = "2.0.0"
+project.version             = "2.1.0"
 
 ext.projectGroupId          = "com.github.detro"
 ext.projectArtifactId       = "phantomjsdriver"

--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSCommandExecutor.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSCommandExecutor.java
@@ -87,7 +87,7 @@ class PhantomJSCommandExecutor extends HttpCommandExecutor {
                     !service.isRunning()) {
                 throw new WebDriverException("The PhantomJS/GhostDriver server has unexpectedly died!", t);
             }
-            Throwables.propagateIfPossible(t);
+            Throwables.throwIfUnchecked(t);
             throw new WebDriverException(t);
         } finally {
             if (DriverCommand.QUIT.equals(command.getName())) {

--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
@@ -231,7 +231,6 @@ public class PhantomJSDriverService extends DriverService {
      * @return The driver executable as a {@link File} object
      * @throws IllegalStateException If the executable not found or cannot be executed
      */
-    @SuppressWarnings("deprecation")
     protected static File findPhantomJS(Capabilities desiredCapabilities, String docsLink,
                                         String downloadLink) {
         String phantomjspath;

--- a/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
+++ b/binding/java/src/main/java/org/openqa/selenium/phantomjs/PhantomJSDriverService.java
@@ -33,7 +33,7 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.net.PortProber;
-import org.openqa.selenium.os.CommandLine;
+import org.openqa.selenium.os.ExecutableFinder;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.File;
@@ -239,7 +239,7 @@ public class PhantomJSDriverService extends DriverService {
                 desiredCapabilities.getCapability(PHANTOMJS_EXECUTABLE_PATH_PROPERTY) != null) {
             phantomjspath = (String) desiredCapabilities.getCapability(PHANTOMJS_EXECUTABLE_PATH_PROPERTY);
         } else {
-            phantomjspath = CommandLine.find(PHANTOMJS_DEFAULT_EXECUTABLE);
+            phantomjspath = new ExecutableFinder().find(PHANTOMJS_DEFAULT_EXECUTABLE);
             phantomjspath = System.getProperty(PHANTOMJS_EXECUTABLE_PATH_PROPERTY, phantomjspath);
         }
 

--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,7 @@ ghostdriver = {
     logger  : require("./logger.js"),
     webdriver_logger  : require("./webdriver_logger.js"),
     config  : null,                         //< this will be set below
-    version : "2.0.0"
+    version : "2.1.0"
 };
 
 // create logger

--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -39,11 +39,11 @@ repositories {
 }
 
 ext.commonsFileUploadVersion = "1.3"
-ext.seleniumVersion = "3.0.0"
+ext.seleniumVersion = "3.1.0"
 ext.jettyVersion = "6.1.21"
 ext.jsr305Version = "2.0.1"
 ext.browsermobProxyClientVersion = "0.1.3"
-ext.phantomjsdriverVersion = "2.0.0"
+ext.phantomjsdriverVersion = "2.1.0"
 
 configurations {
     // introduces a transitive dependency on selenium 2.53


### PR DESCRIPTION
this fix works around a deprecated api in the selenium client.

this change upgrades the selenium dependency from 3.0.0 to 3.1.0.  hence i bumped the ghostdriver version from 2.0.0 to 2.1.0.

fixes #528 