### PR TITLE
Allow specifying path for storing cookies

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -113,7 +113,8 @@ ghostdriver.Session = function(desiredCapabilities) {
     },
     _windows = {},  //< NOTE: windows are "webpage" in Phantom-dialect
     _currentWindowHandle = null,
-    _cookieJar = require('cookiejar').create(),
+    _cookieJar,
+    _cookiePath = null,
     _id = require("./third_party/uuid.js").v1(),
     _inputs = ghostdriver.Inputs(),
     _capsPageSettingsPref = "phantomjs.page.settings.",
@@ -138,6 +139,12 @@ ghostdriver.Session = function(desiredCapabilities) {
     _pageCustomHeaders = {},
     _log = ghostdriver.logger.create("Session [" + _id + "]"),
     k, settingKey, headerKey, proxySettings;
+
+    if (desiredCapabilities['phantomjs.cookies.path']) {
+      _cookiePath = desiredCapabilities['phantomjs.cookies.path'];
+      _negotiatedCapabilities['phantomjs.cookies.path'] = _cookiePath;
+    }
+    _cookieJar = require('cookiejar').create(_cookiePath);
 
     var
     /**


### PR DESCRIPTION
In current implementation of ghostdriver there is no way to load cookies when starting a session. Passing --cookies-file to phantomjs doesn't work because ghostdriver's session.js creates a new cookie jar without any argument, which doesn't allow us to load or save cookies.

I have added "phantomjs.cookies.path" capability that lets you specify the path for the cookie jar.
